### PR TITLE
Refactor PortabilityStackInMemoryDataCopier to improve clarity

### DIFF
--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStore.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStore.java
@@ -2,9 +2,9 @@ package org.datatransferproject.spi.cloud.storage;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Stack;
 import java.util.UUID;
 import org.datatransferproject.spi.cloud.types.JobAuthorization;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
@@ -151,7 +151,7 @@ public interface JobStore extends TemporaryPerJobDataStore {
    * Returns a stack of export information associated with outstanding job iterations - used to
    * resume job transfer.
    */
-  default Optional<Stack<ExportInformation>> loadJobStack(UUID jobId) {
+  default Optional<Deque<ExportInformation>> loadJobStack(UUID jobId) {
     return Optional.empty();
   }
 
@@ -159,7 +159,7 @@ public interface JobStore extends TemporaryPerJobDataStore {
    * Stores a stack of export information associated with the remaining copy iterations left in a job
    * transfer.
    */
-  default void storeJobStack(UUID jobId, Stack<ExportInformation> stack) {}
+  default void storeJobStack(UUID jobId, Deque<ExportInformation> stack) {}
 
   /**
    * Called by a transfer worker when abandoning the job matching {@code jobId}, and do cleanup at their end.

--- a/portability-transfer/src/test/java/org/datatransferproject/transfer/copier/PortabilityInMemoryDataCopierTest.java
+++ b/portability-transfer/src/test/java/org/datatransferproject/transfer/copier/PortabilityInMemoryDataCopierTest.java
@@ -16,11 +16,16 @@
 
 package org.datatransferproject.transfer.copier;
 
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Deque;
 import java.util.Optional;
-import java.util.Stack;
 import java.util.UUID;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.copier.stack.PortabilityStackInMemoryDataCopier;
@@ -424,10 +429,10 @@ public class PortabilityInMemoryDataCopierTest {
     ExportInformation subResource1ExportInfo = new ExportInformation(null, subResource1);
     ExportInformation subResource2ExportInfo = new ExportInformation(null, subResource2);
 
-    Stack<ExportInformation> jobStack = new Stack<>();
-    jobStack.push(subResource2ExportInfo);
-    jobStack.push(subResource1ExportInfo);
-    jobStack.push(paginationExportInfo);
+    Deque<ExportInformation> jobStack = new ArrayDeque<>();
+    jobStack.addLast(subResource2ExportInfo);
+    jobStack.addLast(subResource1ExportInfo);
+    jobStack.addLast(paginationExportInfo);
 
     Mockito.when(continuationData.getPaginationData()).thenReturn(paginationData);
     Mockito.when(continuationData.getContainerResources())
@@ -441,13 +446,17 @@ public class PortabilityInMemoryDataCopierTest {
     stackInMemoryDataCopier.copy(exportAuthData, importAuthData, jobId, Optional.of(exportInfo));
 
     InOrder orderVerifier = Mockito.inOrder(stackInMemoryDataCopier.jobStore);
-    orderVerifier.verify(stackInMemoryDataCopier.jobStore).storeJobStack(jobId, jobStack);
-    jobStack.pop();
-    orderVerifier.verify(stackInMemoryDataCopier.jobStore).storeJobStack(jobId, jobStack);
-    jobStack.pop();
-    orderVerifier.verify(stackInMemoryDataCopier.jobStore).storeJobStack(jobId, jobStack);
-    jobStack.pop();
-    orderVerifier.verify(stackInMemoryDataCopier.jobStore).storeJobStack(jobId, jobStack);
+    while (!jobStack.isEmpty()) {
+      orderVerifier.verify(stackInMemoryDataCopier.jobStore)
+          .storeJobStack(eq(jobId), argThat(s -> dequeEquals(s, jobStack)));
+      jobStack.removeLast();
+    }
+    orderVerifier.verify(stackInMemoryDataCopier.jobStore)
+        .storeJobStack(eq(jobId), argThat(Collection::isEmpty));
+  }
+
+  private boolean dequeEquals(Deque<ExportInformation> d1, Deque<ExportInformation> d2) {
+    return Arrays.equals(d1.toArray(), d2.toArray());
   }
 
   @Test
@@ -455,7 +464,7 @@ public class PortabilityInMemoryDataCopierTest {
       throws CopyException, IOException {
 
     Mockito.when(stackInMemoryDataCopier.jobStore.loadJobStack(jobId))
-        .thenReturn(Optional.of(new Stack<ExportInformation>()));
+        .thenReturn(Optional.of(new ArrayDeque<>()));
 
     stackInMemoryDataCopier.copy(exportAuthData, importAuthData, jobId, Optional.of(exportInfo));
 


### PR DESCRIPTION
- Reduce code duplication by extracting duplicate code into a method
- Replace usages of Stack (it's been deprecated for ages and calls synchronize with every call) with Deque.


