### PR TITLE
Migrate setup-java action to use Temurin

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: gradle
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew


### PR DESCRIPTION
AdoptOpenJDK has moved to the Eclipse Foundation and now distributes binaries under the new name "Eclipse Temurin"