### PR TITLE
Modification for-> There is a vulnerability in Jetty: Java based HTTP…

### DIFF
--- a/extensions/transport/portability-transport-jettyrest/build.gradle
+++ b/extensions/transport/portability-transport-jettyrest/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
     compile group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.0'
 
-    compile('org.eclipse.jetty:jetty-webapp:9.4.8.v20171121') {
+    compile('org.eclipse.jetty:jetty-webapp:9.4.35.v20201120') {
         exclude module: 'jetty-xml'
     }
 


### PR DESCRIPTION
Modified the version as mentioned in the issue --> There is a vulnerability in Jetty: Java based HTTP/1.x, HTTP/2, Servlet, WebSocket Server 9.4.8.v20171121,upgrade recommended #948