### PR TITLE
Remove check for `authPublicKey` when claiming jobs

### DIFF
--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
@@ -153,11 +153,6 @@ class JobPollingService extends AbstractScheduledService {
     // Lookup the job so we can append to its existing properties.
     PortabilityJob existingJob = store.findJob(jobId);
     monitor.debug(() -> format("JobPollingService: tryToClaimJob: jobId: %s", existingJob));
-    // Verify no transfer worker key
-    if (existingJob.jobAuthorization().authPublicKey() != null) {
-      monitor.debug(() -> "A public key cannot be persisted again");
-      return false;
-    }
 
     // TODO: Consider moving this check earlier in the flow
     String scheme = existingJob.jobAuthorization().encryptionScheme();


### PR DESCRIPTION
This check was originally added in 9d5302c, where it was used to check that two workers didn't attempt to claim the same job. Since then the surrounding code has seen a lot of refactoring, including migrating to calling `claimJob` on the job store which, per the comment in `JobPollingService` and on the `JobStore` interface docs, should do the job of ensuring this doesn't happen.

Removing this line unblocks the option of allowing workers to reclaim jobs from another crashed worker that couldn't inform the job store it was exiting (e.g. OOM killed), but also continues to allow blocking `claimJob` on claimed jobs by delegating that decision to the `JobStore`.