### PR TITLE
Add counts to MusicMediaContainer

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/constants/AppleMusicConstants.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/constants/AppleMusicConstants.java
@@ -24,8 +24,4 @@ public class AppleMusicConstants {
     // Maximum number of playlist items to import in a single request
     public static final Integer MAX_NEW_PLAYLIST_ITEM_REQUESTS = Integer.parseInt(System.getProperty("AppleMusicImporter.MAX_NEW_PLAYLIST_ITEM_REQUESTS", "100"));
 
-    public static final String PLAYLISTS_COUNT_DATA_NAME = "playlistsCount";
-
-    public static final String PLAYLIST_ITEMS_COUNT_DATA_NAME = "playlistItemsCount";
-
 }

--- a/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/music/AppleMusicImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/music/AppleMusicImporter.java
@@ -90,8 +90,8 @@ public class AppleMusicImporter implements Importer<TokensAndUrlAuthData, MusicC
 
         final Map<String, Integer> counts =
                 new ImmutableMap.Builder<String, Integer>()
-                        .put(AppleMusicConstants.PLAYLISTS_COUNT_DATA_NAME, playlistsCount)
-                        .put(AppleMusicConstants.PLAYLIST_ITEMS_COUNT_DATA_NAME, playlistItemsCount)
+                        .put(MusicContainerResource.PLAYLIST_COUNT_DATA_NAME, playlistsCount)
+                        .put(MusicContainerResource.PLAYLIST_ITEM_COUNT_DATA_NAME, playlistItemsCount)
                         .build();
         return ImportResult.OK
                 .copyWithCounts(counts);

--- a/extensions/data-transfer/portability-data-transfer-apple/src/test/java/org/datatransferproject/datatransfer/apple/music/AppleMusicImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/test/java/org/datatransferproject/datatransfer/apple/music/AppleMusicImporterTest.java
@@ -134,9 +134,9 @@ public class AppleMusicImporterTest {
         assertThat(importResult.getCounts().isPresent());
 
         // Should be the same as the number of playlists sent in.
-        assertThat(importResult.getCounts().get().get(AppleMusicConstants.PLAYLISTS_COUNT_DATA_NAME) == playlistsResource.getPlaylists().size());
+        assertThat(importResult.getCounts().get().get(MusicContainerResource.PLAYLIST_COUNT_DATA_NAME) == playlistsResource.getPlaylists().size());
         // No playlist items were sent.
-        assertThat(importResult.getCounts().get().get(AppleMusicConstants.PLAYLIST_ITEMS_COUNT_DATA_NAME) == 0);
+        assertThat(importResult.getCounts().get().get(MusicContainerResource.PLAYLIST_ITEM_COUNT_DATA_NAME) == 0);
     }
 
     @Test
@@ -198,9 +198,9 @@ public class AppleMusicImporterTest {
 
         assertThat(importResult.getCounts().isPresent());
 
-        assertThat(importResult.getCounts().get().get(AppleMusicConstants.PLAYLIST_ITEMS_COUNT_DATA_NAME) == playlistItemsResource.getPlaylistItems().size());
+        assertThat(importResult.getCounts().get().get(MusicContainerResource.PLAYLIST_ITEM_COUNT_DATA_NAME) == playlistItemsResource.getPlaylistItems().size());
 
-        assertThat(importResult.getCounts().get().get(AppleMusicConstants.PLAYLISTS_COUNT_DATA_NAME) == 0);
+        assertThat(importResult.getCounts().get().get(MusicContainerResource.PLAYLIST_COUNT_DATA_NAME) == 0);
     }
 
     @Test
@@ -241,9 +241,9 @@ public class AppleMusicImporterTest {
         assertThat(executor.getErrors()).isEmpty();
         assertThat(importResult.getCounts().isPresent());
 
-        assertThat(importResult.getCounts().get().get(AppleMusicConstants.PLAYLIST_ITEMS_COUNT_DATA_NAME) == itemsResource.getPlaylistItems().size());
+        assertThat(importResult.getCounts().get().get(MusicContainerResource.PLAYLIST_ITEM_COUNT_DATA_NAME) == itemsResource.getPlaylistItems().size());
 
-        assertThat(importResult.getCounts().get().get(AppleMusicConstants.PLAYLISTS_COUNT_DATA_NAME) == 0);
+        assertThat(importResult.getCounts().get().get(MusicContainerResource.PLAYLIST_COUNT_DATA_NAME) == 0);
     }
 
     private void setUpImportPlaylistTracksBatchResponse(@Nonnull final Map<String, Integer> dataIdToStatus) throws Exception {

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/music/MusicContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/music/MusicContainerResource.java
@@ -43,6 +43,10 @@ public class MusicContainerResource extends ContainerResource {
   public static final String PLAYLIST_COUNT_DATA_NAME = "playlistCount";
   public static final String PLAYLIST_ITEM_COUNT_DATA_NAME = "playlistItemCount";
 
+  public static final String TRACK_COUNT_DATA_NAME = "trackCount";
+
+  public static final String RELEASES_COUNT_DATA_NAME = "releaseCount";
+
   @JsonCreator
   public MusicContainerResource(
       @JsonProperty("playlists") Collection<MusicPlaylist> playlists,
@@ -106,6 +110,8 @@ public class MusicContainerResource extends ContainerResource {
     return new ImmutableMap.Builder<String, Integer>()
             .put(PLAYLIST_COUNT_DATA_NAME, playlists.size())
             .put(PLAYLIST_ITEM_COUNT_DATA_NAME, playlistItems.size())
+            .put(TRACK_COUNT_DATA_NAME, tracks.size())
+            .put(RELEASES_COUNT_DATA_NAME, releases.size())
             .build();
   }
 

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/music/MusicContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/music/MusicContainerResource.java
@@ -21,9 +21,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.datatransferproject.types.common.models.ContainerResource;
 
@@ -37,6 +39,9 @@ public class MusicContainerResource extends ContainerResource {
   private final List<MusicPlaylistItem> playlistItems;
   private final Collection<MusicRecording> tracks;
   private final Collection<MusicRelease> releases;
+
+  public static final String PLAYLIST_COUNT_DATA_NAME = "playlistCount";
+  public static final String PLAYLIST_ITEM_COUNT_DATA_NAME = "playlistItemCount";
 
   @JsonCreator
   public MusicContainerResource(
@@ -95,4 +100,13 @@ public class MusicContainerResource extends ContainerResource {
         .add("releases", getReleases())
         .toString();
   }
+
+  @Override
+  public Map<String, Integer> getCounts() {
+    return new ImmutableMap.Builder<String, Integer>()
+            .put(PLAYLIST_COUNT_DATA_NAME, playlists.size())
+            .put(PLAYLIST_ITEM_COUNT_DATA_NAME, playlistItems.size())
+            .build();
+  }
+
 }


### PR DESCRIPTION
We were trying to figure out why no counts were written for MUSIC jobs even though the AppleMusicImporter sets the counts here: https://github.com/dtinit/data-transfer-project/blob/822e0e7f0750f2cbf6de8cb2948601842d3b62e3/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/music/AppleMusicImporter.java#L91-L97 

And this should be preserved the same way photos counts are preserved

Upon investigating it looks like we completely disregard the counts returned from the importer in favor of the counts that are with the original exported data here: https://github.com/dtinit/data-transfer-project/blob/822e0e7f0750f2cbf6de8cb2948601842d3b62e3/portability-transfer/src/main/java/org/datatransferproject/transfer/CallableImporter.java#L80 

Which works for Media jobs because the MediaContainerResource overrides the getCounts method here: https://github.com/dtinit/data-transfer-project/blob/822e0e7f0750f2cbf6de8cb2948601842d3b62e3/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaContainerResource.java#L112-L118

This PR adds a getCounts method to the MusicMediaContainer and updates the strings that are used in the AppleMusicImporter to be the central strings instead (this prevents a mismatch in the strings that are being used)

This PR just makes things operate as they are operating for photos/media, however the larger question is in the callable importer which counts we want to use (the ones from the result of the import or the ones from the data) and that is likely a larger discussion to be had. 

This also means that Apple->YTM transfers now have count information as well since the GoogleMusicImporter does not return counts 