### PR TITLE
Fix Guice Injection error with transferSignalEnabled flag

### DIFF
--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-
 import com.google.inject.name.Named;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Optional;

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerModule.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerModule.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -313,7 +314,8 @@ final class WorkerModule extends FlagBindingModule {
     return idempotentImportExecutorExtension.getRetryingIdempotentImportExecutor(context);
   }
 
-  @Flag
+  @Provides
+  @Named("transferSignalEnabled")
   public Boolean transferSignalEnabled() {
     return context.getSetting("transferSignalEnabled", Boolean.TRUE);
   }


### PR DESCRIPTION
We're seeing a guice error when trying to start a worker, this looks like its happening because the JobProcessor is looking for an `@Named` object while the WorkerModule provides it as an `@Flag` object (and also isnt marked as `@Provides`). Im not sure what the original usecase of the `@Flag` argument is for but it also doesnt look like we use it outside of the extension contexts 

```
2024-09-11 14:30:28.888676-05001   [34mINFO 2024-09-11T19:30:28.889469 Using InMemoryDataCopier: org.datatransferproject.transfer.copier.PortabilityInMemoryDataCopier[0m
 2024-09-11 14:30:29.045224-05001   Sep 11, 2024 7:30:29 PM com.google.common.util.concurrent.UncaughtExceptionHandlers$Exiter uncaughtException
 2024-09-11 14:30:29.045244-05001   SEVERE: Caught an exception in Thread[#1,main,5,main].  Shutting down.
 2024-09-11 14:30:29.045247-05001   com.google.inject.ConfigurationException: Guice configuration errors:
 2024-09-11 14:30:29.045272-05001   
 2024-09-11 14:30:29.045274-05001   1) [Guice/MissingImplementation]: No implementation for Boolean annotated with @Named("transferSignalEnabled") was bound.
 2024-09-11 14:30:29.045276-05001   
 2024-09-11 14:30:29.045277-05001   Requested by:
 2024-09-11 14:30:29.045278-05001   1  : JobProcessor.<init>(JobProcessor.java:85)
 2024-09-11 14:30:29.045279-05001         \_ for 8th parameter transferSignalEnabled
 2024-09-11 14:30:29.045281-05001        at Worker.<init>(Worker.java:30)
 2024-09-11 14:30:29.045282-05001         \_ for 3rd parameter jobProcessor
 2024-09-11 14:30:29.045283-05001        while locating Worker
 2024-09-11 14:30:29.045285-05001   
 2024-09-11 14:30:29.045286-05001   Learn more:
 2024-09-11 14:30:29.045287-05001     http://go/guice/error/MISSING_IMPLEMENTATION
 2024-09-11 14:30:29.045289-05001   
 2024-09-11 14:30:29.045290-05001   1 error
 2024-09-11 14:30:29.045291-05001   
 2024-09-11 14:30:29.045292-05001   ======================
 2024-09-11 14:30:29.045293-05001   Full classname legend:
 2024-09-11 14:30:29.045294-05001   ======================
 2024-09-11 14:30:29.045295-05001   JobProcessor: "org.datatransferproject.transfer.JobProcessor"
 2024-09-11 14:30:29.045296-05001   Named:        "com.google.inject.name.Named"
 2024-09-11 14:30:29.045297-05001   Worker:       "org.datatransferproject.transfer.Worker"
 2024-09-11 14:30:29.045299-05001   ========================
 2024-09-11 14:30:29.045300-05001   End of classname legend:
 2024-09-11 14:30:29.045301-05001   ========================
 2024-09-11 14:30:29.045303-05001   
 2024-09-11 14:30:29.045304-05001   	at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:1174)
 2024-09-11 14:30:29.045306-05001   	at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:1134)
 2024-09-11 14:30:29.045307-05001   	at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1186)
 2024-09-11 14:30:29.045309-05001   	at org.datatransferproject.transfer.WorkerMain.initialize(WorkerMain.java:137)
 2024-09-11 14:30:29.045310-05001   	at org.datatransferproject.transfer.WorkerMain.main(WorkerMain.java:64)
```