### PR TITLE
noop(cleanup) run clang-format (enforce goog style)

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporter.java
@@ -359,9 +359,13 @@ public class MicrosoftMediaImporter
   /**
    * Forms the URL to create an upload session.
    *
-   * <p>Creates an upload session path for one of two cases: - 1) POST to
-   * /me/drive/items/{folder_id}:/{file_name}:/createUploadSession - 2) GET {uploadurl} from
-   * /me/drive/items/root:/photos-video/{file_name}:/createUploadSession
+   * <p>Creates an upload session path for one of two cases:
+   *
+   * <ul>
+   *   <li>- 1) POST to /me/drive/items/{folder_id}:/{file_name}:/createUploadSession
+   *   <li>- 2) GET {uploadurl} from
+   *       /me/drive/items/root:/photos-video/{file_name}:/createUploadSession
+   * </ul>
    */
   private Request.Builder buildCreateUploadSessionPath(
       DownloadableFile item, IdempotentImportExecutor idempotentImportExecutor) {

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporter.java
@@ -22,7 +22,6 @@ import com.google.api.client.auth.oauth2.Credential;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
@@ -39,8 +38,6 @@ import okhttp3.ResponseBody;
 import org.apache.commons.lang3.tuple.Pair;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.api.transport.JobFileStream;
-import org.datatransferproject.spi.api.transport.RemoteFileStreamer;
-import org.datatransferproject.spi.api.transport.UrlGetStreamer;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
@@ -79,13 +76,17 @@ public class MicrosoftMediaImporter
 
   private static final String UPLOAD_PARAMS = "?@microsoft.graph.conflictBehavior=rename";
 
-  public MicrosoftMediaImporter(String baseUrl, OkHttpClient client, ObjectMapper objectMapper,
-      TemporaryPerJobDataStore jobStore, Monitor monitor,
+  public MicrosoftMediaImporter(
+      String baseUrl,
+      OkHttpClient client,
+      ObjectMapper objectMapper,
+      TemporaryPerJobDataStore jobStore,
+      Monitor monitor,
       MicrosoftCredentialFactory credentialFactory,
       JobFileStream jobFileStream) {
 
     // NOTE: "special/photos" is a specific folder in One Drive that corresponds to items that
-    // should appear in https://photos.onedrive.com/, for more information see:  
+    // should appear in https://photos.onedrive.com/, for more information see:
     // https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/drive_get_specialfolder?#special-folder-names
     createFolderUrl = baseUrl + "/v1.0/me/drive/special/photos/children";
     albumlessMediaUrlTemplate =
@@ -105,8 +106,12 @@ public class MicrosoftMediaImporter
   }
 
   @Override
-  public ImportResult importItem(UUID jobId, IdempotentImportExecutor idempotentImportExecutor,
-      TokensAndUrlAuthData authData, MediaContainerResource resource) throws Exception {
+  public ImportResult importItem(
+      UUID jobId,
+      IdempotentImportExecutor idempotentImportExecutor,
+      TokensAndUrlAuthData authData,
+      MediaContainerResource resource)
+      throws Exception {
     // Ensure credential is populated
     getOrCreateCredential(authData);
 
@@ -134,19 +139,17 @@ public class MicrosoftMediaImporter
    * Logs brief debugging message describing current state of job given `resource`.
    *
    * @param format a printf-style formatter that exactly one parameter: the string of the job's
-   *   current status.
+   *     current status.
    */
-  private void logDebugJobStatus(
-      String format,
-      UUID jobId,
-      MediaContainerResource resource) {
-    String statusMessage = String.format(
-        "%s: Importing %s albums, %s photos, and %s videos",
-        jobId,
-        resource.getAlbums().size(),
-        resource.getPhotos().size(),
-        resource.getVideos().size());
-    monitor.debug(() ->  String.format(format, statusMessage));
+  private void logDebugJobStatus(String format, UUID jobId, MediaContainerResource resource) {
+    String statusMessage =
+        String.format(
+            "%s: Importing %s albums, %s photos, and %s videos",
+            jobId,
+            resource.getAlbums().size(),
+            resource.getPhotos().size(),
+            resource.getVideos().size());
+    monitor.debug(() -> String.format(format, statusMessage));
   }
 
   @SuppressWarnings("unchecked")
@@ -165,8 +168,9 @@ public class MicrosoftMediaImporter
 
     Request.Builder requestBuilder = new Request.Builder().url(createFolderUrl);
     requestBuilder.header("Authorization", "Bearer " + credential.getAccessToken());
-    requestBuilder.post(RequestBody.create(
-        MediaType.parse("application/json"), objectMapper.writeValueAsString(rawFolder)));
+    requestBuilder.post(
+        RequestBody.create(
+            MediaType.parse("application/json"), objectMapper.writeValueAsString(rawFolder)));
     try (Response response = client.newCall(requestBuilder.build()).execute()) {
       int code = response.code();
       ResponseBody body = response.body();
@@ -182,12 +186,18 @@ public class MicrosoftMediaImporter
       }
 
       if (code == 403 && response.message().contains("Access Denied")) {
-        throw new PermissionDeniedException("User access to microsoft onedrive was denied",
+        throw new PermissionDeniedException(
+            "User access to microsoft onedrive was denied",
             new IOException(
                 String.format("Got error code %d  with message: %s", code, response.message())));
       } else if (code < 200 || code > 299) {
-        throw new IOException("Got error code: " + code + " message: " + response.message()
-            + " body: " + response.body().string());
+        throw new IOException(
+            "Got error code: "
+                + code
+                + " message: "
+                + response.message()
+                + " body: "
+                + response.body().string());
       } else if (body == null) {
         throw new IOException("Got null body");
       }
@@ -203,10 +213,12 @@ public class MicrosoftMediaImporter
   private void executeIdempotentImport(
       UUID jobId,
       IdempotentImportExecutor idempotentImportExecutor,
-      Collection<? extends DownloadableFile> downloadableFiles) throws Exception {
+      Collection<? extends DownloadableFile> downloadableFiles)
+      throws Exception {
     for (DownloadableFile downloadableFile : downloadableFiles) {
       idempotentImportExecutor.executeAndSwallowIOExceptions(
-          downloadableFile.getIdempotentId(), downloadableFile.getName(),
+          downloadableFile.getIdempotentId(),
+          downloadableFile.getName(),
           () -> importDownloadableItem(downloadableFile, jobId, idempotentImportExecutor));
     }
   }
@@ -216,9 +228,10 @@ public class MicrosoftMediaImporter
       throws Exception {
     final long totalFileSize = discardForLength(jobFileStream.streamFile(item, jobId, jobStore));
     if (totalFileSize <= 0) {
-      throw new IOException(String.format(
-          "jobid %s hit empty unexpectedly empty (bytes=%d) download for file %s",
-          jobId, totalFileSize, item.getFetchableUrl()));
+      throw new IOException(
+          String.format(
+              "jobid %s hit empty unexpectedly empty (bytes=%d) download for file %s",
+              jobId, totalFileSize, item.getFetchableUrl()));
     }
     InputStream fileStream = jobFileStream.streamFile(item, jobId, jobStore);
 
@@ -242,7 +255,8 @@ public class MicrosoftMediaImporter
 
   /** Depletes input stream, uploading a chunk of the stream at a time. */
   private Response uploadStreamInChunks(
-      long totalFileSize, String itemUploadUrl, String itemMimeType, InputStream inputStream) throws IOException, DestinationMemoryFullException {
+      long totalFileSize, String itemUploadUrl, String itemMimeType, InputStream inputStream)
+      throws IOException, DestinationMemoryFullException {
     Response lastChunkResponse = null;
     StreamChunker streamChunker = new StreamChunker(MICROSOFT_UPLOAD_CHUNK_BYTE_SIZE, inputStream);
     Optional<DataChunk> nextChunk;
@@ -251,8 +265,7 @@ public class MicrosoftMediaImporter
       if (nextChunk.isEmpty()) {
         break;
       }
-      lastChunkResponse =
-          uploadChunk(nextChunk.get(), itemUploadUrl, totalFileSize, itemMimeType);
+      lastChunkResponse = uploadChunk(nextChunk.get(), itemUploadUrl, totalFileSize, itemMimeType);
     }
     return lastChunkResponse;
   }
@@ -286,37 +299,48 @@ public class MicrosoftMediaImporter
   private String createUploadSession(
       DownloadableFile item, IdempotentImportExecutor idempotentImportExecutor)
       throws IOException, CopyExceptionWithFailureReason {
-    Request.Builder createSessionRequestBuilder = buildCreateUploadSessionPath(item, idempotentImportExecutor);
+    Request.Builder createSessionRequestBuilder =
+        buildCreateUploadSessionPath(item, idempotentImportExecutor);
 
     // Auth headers
     createSessionRequestBuilder.header("Authorization", "Bearer " + credential.getAccessToken());
     createSessionRequestBuilder.header("Content-Type", "application/json");
 
     // Post request with empty body. If you don't include an empty body, you'll have problems
-    createSessionRequestBuilder.post(RequestBody.create(
-        MediaType.parse("application/json"), objectMapper.writeValueAsString(ImmutableMap.of())));
+    createSessionRequestBuilder.post(
+        RequestBody.create(
+            MediaType.parse("application/json"),
+            objectMapper.writeValueAsString(ImmutableMap.of())));
 
     // Make the call, we should get an upload url for item data in a 200 response
     Pair<Request, Response> reqResp = tryWithCreds(createSessionRequestBuilder);
     Response response = reqResp.getRight();
     int code = response.code();
     if (code == 403 && response.message().contains("Access Denied")) {
-      throw new PermissionDeniedException("User access to Microsoft One Drive was denied",
+      throw new PermissionDeniedException(
+          "User access to Microsoft One Drive was denied",
           new IOException(
               String.format("Got error code %d  with message: %s", code, response.message())));
     } else if (code == 507 && response.message().contains("Insufficient Storage")) {
-      throw new DestinationMemoryFullException("Microsoft destination storage limit reached",
+      throw new DestinationMemoryFullException(
+          "Microsoft destination storage limit reached",
           new IOException(
               String.format("Got error code %d  with message: %s", code, response.message())));
     } else if (code < 200 || code > 299) {
-      throw new IOException(String.format("Got error code: %s\n"
-              + "message: %s\n"
-              + "body: %s\n"
-              + "request url: %s\n"
-              + "bearer token: %s\n"
-              + " item: %s\n", // For debugging 404s on upload
-          code, response.message(), response.body().string(), reqResp.getLeft().url(),
-          credential.getAccessToken(), item));
+      throw new IOException(
+          String.format(
+              "Got error code: %s\n"
+                  + "message: %s\n"
+                  + "body: %s\n"
+                  + "request url: %s\n"
+                  + "bearer token: %s\n"
+                  + " item: %s\n", // For debugging 404s on upload
+              code,
+              response.message(),
+              response.body().string(),
+              reqResp.getLeft().url(),
+              credential.getAccessToken(),
+              item));
     } else if (code != 200) {
       monitor.info(() -> String.format("Got an unexpected non-200, non-error response code"));
     }
@@ -335,13 +359,12 @@ public class MicrosoftMediaImporter
   /**
    * Forms the URL to create an upload session.
    *
-   * Creates an upload session path for one of two cases:
-   * - 1) POST to /me/drive/items/{folder_id}:/{file_name}:/createUploadSession
-   * - 2) GET {uploadurl} from /me/drive/items/root:/photos-video/{file_name}:/createUploadSession
+   * <p>Creates an upload session path for one of two cases: - 1) POST to
+   * /me/drive/items/{folder_id}:/{file_name}:/createUploadSession - 2) GET {uploadurl} from
+   * /me/drive/items/root:/photos-video/{file_name}:/createUploadSession
    */
   private Request.Builder buildCreateUploadSessionPath(
-      DownloadableFile item,
-      IdempotentImportExecutor idempotentImportExecutor) {
+      DownloadableFile item, IdempotentImportExecutor idempotentImportExecutor) {
     String createSessionUrl;
     if (Strings.isNullOrEmpty(item.getFolderId())) {
       createSessionUrl = String.format(albumlessMediaUrlTemplate, item.getName(), UPLOAD_PARAMS);
@@ -360,8 +383,9 @@ public class MicrosoftMediaImporter
   // Content-Length: {chunk size in bytes}
   // Content-Range: bytes {begin}-{end}/{total size}
   // body={bytes}
-  private Response uploadChunk(DataChunk chunk, String photoUploadUrl, long totalFileSize,
-      String mediaType) throws IOException, DestinationMemoryFullException {
+  private Response uploadChunk(
+      DataChunk chunk, String photoUploadUrl, long totalFileSize, String mediaType)
+      throws IOException, DestinationMemoryFullException {
     Request.Builder uploadRequestBuilder = new Request.Builder().url(photoUploadUrl);
     uploadRequestBuilder.header("Authorization", "Bearer " + credential.getAccessToken());
 
@@ -372,7 +396,8 @@ public class MicrosoftMediaImporter
 
     // set chunk data headers, indicating size and chunk range
     final String contentRange =
-        String.format("bytes %d-%d/%d", chunk.streamByteOffset(), chunk.finalByteOffset(), totalFileSize);
+        String.format(
+            "bytes %d-%d/%d", chunk.streamByteOffset(), chunk.finalByteOffset(), totalFileSize);
     uploadRequestBuilder.header("Content-Range", contentRange);
     uploadRequestBuilder.header("Content-Length", String.format("%d", chunk.size()));
 
@@ -390,17 +415,23 @@ public class MicrosoftMediaImporter
     }
     int chunkCode = chunkResponse.code();
     if (chunkCode == 507 && chunkResponse.message().contains("Insufficient Storage")) {
-      throw new DestinationMemoryFullException("Microsoft destination storage limit reached",
-          new IOException(String.format(
-              "Got error HTTP status %d  with message: %s", chunkCode, chunkResponse.message())));
+      throw new DestinationMemoryFullException(
+          "Microsoft destination storage limit reached",
+          new IOException(
+              String.format(
+                  "Got error HTTP status %d  with message: %s",
+                  chunkCode, chunkResponse.message())));
     } else if (chunkCode < 200 || chunkCode > 299) {
-      throw new IOException(String.format(
-          "Got error HTTP status: %d message: \"%s\" body: \"%s\"", chunkCode, chunkResponse.message(),
-          chunkResponse.body().string()));
+      throw new IOException(
+          String.format(
+              "Got error HTTP status: %d message: \"%s\" body: \"%s\"",
+              chunkCode, chunkResponse.message(), chunkResponse.body().string()));
     } else if (chunkCode == 200 || chunkCode == 201 || chunkCode == 202) {
-      monitor.info(()
-                       -> String.format("Uploaded chunk range %d-%d (of total bytesize: %d) successfuly, HTTP status %d",
-                           chunk.streamByteOffset(), chunk.finalByteOffset(), totalFileSize, chunkCode));
+      monitor.info(
+          () ->
+              String.format(
+                  "Uploaded chunk range %d-%d (of total bytesize: %d) successfuly, HTTP status %d",
+                  chunk.streamByteOffset(), chunk.finalByteOffset(), totalFileSize, chunkCode));
     }
     return chunkResponse;
   }

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporterTest.java
@@ -62,8 +62,8 @@ import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.stubbing.Answer;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 /**
  * This tests the MicrosoftMediaImporter. As of now, it only tests the number of requests called.
@@ -72,8 +72,8 @@ import org.mockito.invocation.InvocationOnMock;
 public class MicrosoftMediaImporterTest {
 
   private static final int CHUNK_SIZE = 32000 * 1024; // 32000KiB
-  private final static String BASE_URL = "https://www.baseurl.com";
-  private final static UUID uuid = UUID.randomUUID();
+  private static final String BASE_URL = "https://www.baseurl.com";
+  private static final UUID uuid = UUID.randomUUID();
 
   MicrosoftMediaImporter importer;
   OkHttpClient client;
@@ -105,7 +105,13 @@ public class MicrosoftMediaImporterTest {
     credential.setExpirationTimeMilliseconds(null);
     importer =
         new MicrosoftMediaImporter(
-            BASE_URL, client, objectMapper, jobStore, monitor, credentialFactory, new JobFileStream(remoteFileStreamer));
+            BASE_URL,
+            client,
+            objectMapper,
+            jobStore,
+            monitor,
+            credentialFactory,
+            new JobFileStream(remoteFileStreamer));
   }
 
   @Test
@@ -113,25 +119,30 @@ public class MicrosoftMediaImporterTest {
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "album1.", "This is a fake albumb"));
 
-    MediaContainerResource data = new MediaContainerResource(albums, null /*phots*/,
-        null /*videos*/);
+    MediaContainerResource data =
+        new MediaContainerResource(albums, null /*phots*/, null /*videos*/);
 
     Call call = mock(Call.class);
-    doReturn(call).when(client).newCall(argThat((Request r) -> {
-      String body = "";
+    doReturn(call)
+        .when(client)
+        .newCall(
+            argThat(
+                (Request r) -> {
+                  String body = "";
 
-      try {
-        final Buffer buffer = new Buffer();
-        r.body().writeTo(buffer);
-        body = buffer.readUtf8();
-      } catch (IOException e) {
-        return false;
-      }
+                  try {
+                    final Buffer buffer = new Buffer();
+                    r.body().writeTo(buffer);
+                    body = buffer.readUtf8();
+                  } catch (IOException e) {
+                    return false;
+                  }
 
-      return r.url().toString().equals(
-          "https://www.baseurl.com/v1.0/me/drive/special/photos/children")
-          && body.contains("album1_");
-    }));
+                  return r.url()
+                          .toString()
+                          .equals("https://www.baseurl.com/v1.0/me/drive/special/photos/children")
+                      && body.contains("album1_");
+                }));
     Response response = mock(Response.class);
     ResponseBody body = mock(ResponseBody.class);
     when(body.bytes())
@@ -154,14 +165,18 @@ public class MicrosoftMediaImporterTest {
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "album1.", "This is a fake albumb"));
 
-    MediaContainerResource data = new MediaContainerResource(albums, null /*photos*/,
-        null /*videos*/);
+    MediaContainerResource data =
+        new MediaContainerResource(albums, null /*photos*/, null /*videos*/);
 
     Call call = mock(Call.class);
-    doReturn(call).when(client).newCall(
-        argThat((Request r)
-            -> r.url().toString().equals(
-            "https://www.baseurl.com/v1.0/me/drive/special/photos/children")));
+    doReturn(call)
+        .when(client)
+        .newCall(
+            argThat(
+                (Request r) ->
+                    r.url()
+                        .toString()
+                        .equals("https://www.baseurl.com/v1.0/me/drive/special/photos/children")));
     Response response = mock(Response.class);
     ResponseBody body = mock(ResponseBody.class);
     when(body.bytes())
@@ -175,23 +190,25 @@ public class MicrosoftMediaImporterTest {
     when(response.body()).thenReturn(body);
     when(call.execute()).thenReturn(response);
 
-    assertThrows(PermissionDeniedException.class, () -> {
-      ImportResult result = importer.importItem(uuid, executor, authData, data);
-    });
+    assertThrows(
+        PermissionDeniedException.class,
+        () -> {
+          ImportResult result = importer.importItem(uuid, executor, authData, data);
+        });
   }
 
   private static <M extends DownloadableFile> M fakeJobstoreModel(
-      TemporaryPerJobDataStore jobStore,
-      M model,
-      byte[] contents) throws IOException {
+      TemporaryPerJobDataStore jobStore, M model, byte[] contents) throws IOException {
     checkState(
         model.isInTempStore(),
         "nonsensical fake: trying to fake a tempstore entry with isInTempStore() set to false");
-    when(jobStore.getStream(uuid, model.getFetchableUrl())) .thenAnswer(new Answer() {
-      public Object answer(InvocationOnMock invocation) {
-        return new InputStreamWrapper(new ByteArrayInputStream(contents));
-      }
-    });
+    when(jobStore.getStream(uuid, model.getFetchableUrl()))
+        .thenAnswer(
+            new Answer() {
+              public Object answer(InvocationOnMock invocation) {
+                return new InputStreamWrapper(new ByteArrayInputStream(contents));
+              }
+            });
     return model;
   }
 
@@ -205,32 +222,36 @@ public class MicrosoftMediaImporterTest {
             fakeJobstoreModel(
                 jobStore,
                 new PhotoModel(
-                  "Pic1",
-                  "http://fake.com/1.jpg",
-                  "A pic",
-                  "image/jpg",
-                  "p1", // dataId
-                  "id1", // albumdId
-                  true /*isInTempStore*/),
+                    "Pic1",
+                    "http://fake.com/1.jpg",
+                    "A pic",
+                    "image/jpg",
+                    "p1", // dataId
+                    "id1", // albumdId
+                    true /*isInTempStore*/),
                 new byte[CHUNK_SIZE]),
             fakeJobstoreModel(
                 jobStore,
                 new PhotoModel(
-                  "Pic2",
-                  "http://fake.com/2.png",
-                  "fine art",
-                  "image/png",
-                  "p2", // dataId
-                  "id1", // albumdId
-                  true /*isInTempStore*/),
+                    "Pic2",
+                    "http://fake.com/2.png",
+                    "fine art",
+                    "image/png",
+                    "p2", // dataId
+                    "id1", // albumdId
+                    true /*isInTempStore*/),
                 new byte[CHUNK_SIZE]));
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*videos*/);
 
     Call call = mock(Call.class);
-    doReturn(call).when(client).newCall(
-        argThat((Request r)
-            -> r.url().toString().equals(
-            "https://www.baseurl.com/v1.0/me/drive/special/photos/children")));
+    doReturn(call)
+        .when(client)
+        .newCall(
+            argThat(
+                (Request r) ->
+                    r.url()
+                        .toString()
+                        .equals("https://www.baseurl.com/v1.0/me/drive/special/photos/children")));
     Response response = mock(Response.class);
     ResponseBody body = mock(ResponseBody.class);
     when(body.bytes())
@@ -244,35 +265,41 @@ public class MicrosoftMediaImporterTest {
     when(call.execute()).thenReturn(response);
 
     Call call2 = mock(Call.class);
-    doReturn(call2).when(client).newCall(
-        argThat((Request r) -> r.url().toString().contains("createUploadSession")));
+    doReturn(call2)
+        .when(client)
+        .newCall(argThat((Request r) -> r.url().toString().contains("createUploadSession")));
     Response response2 = mock(Response.class);
     ResponseBody body2 = mock(ResponseBody.class);
     when(body2.bytes())
-        .thenReturn(ResponseBody
-            .create(MediaType.parse("application/json"),
-                "{\"uploadUrl\": \"https://scalia.com/link\"}")
-            .bytes());
+        .thenReturn(
+            ResponseBody.create(
+                    MediaType.parse("application/json"),
+                    "{\"uploadUrl\": \"https://scalia.com/link\"}")
+                .bytes());
     when(body2.string())
-        .thenReturn(ResponseBody
-            .create(MediaType.parse("application/json"),
-                "{\"uploadUrl\": \"https://scalia.com/link\"}")
-            .string());
+        .thenReturn(
+            ResponseBody.create(
+                    MediaType.parse("application/json"),
+                    "{\"uploadUrl\": \"https://scalia.com/link\"}")
+                .string());
     when(response2.code()).thenReturn(200);
     when(response2.body()).thenReturn(body2);
     when(call2.execute()).thenReturn(response2);
 
     Call call3 = mock(Call.class);
-    doReturn(call3).when(client).newCall(
-        argThat((Request r) -> r.url().toString().contains("scalia.com/link")));
+    doReturn(call3)
+        .when(client)
+        .newCall(argThat((Request r) -> r.url().toString().contains("scalia.com/link")));
     Response response3 = mock(Response.class);
     ResponseBody body3 = mock(ResponseBody.class);
     when(body3.bytes())
-        .thenReturn(ResponseBody.create(MediaType.parse("application/json"), "{\"id\": \"rand1\"}")
-            .bytes());
+        .thenReturn(
+            ResponseBody.create(MediaType.parse("application/json"), "{\"id\": \"rand1\"}")
+                .bytes());
     when(body3.string())
-        .thenReturn(ResponseBody.create(MediaType.parse("application/json"), "{\"id\": \"rand1\"}")
-            .string());
+        .thenReturn(
+            ResponseBody.create(MediaType.parse("application/json"), "{\"id\": \"rand1\"}")
+                .string());
     when(response3.code()).thenReturn(200);
     when(response3.body()).thenReturn(body3);
     when(call3.execute()).thenReturn(response3);


### PR DESCRIPTION
I have to fight this everytime I'm working on or fixing something in this adapter (so that my PRs are easier to read and aren't mixed in with this enormous diff). So just letting it finally run once and for all, and merge it as a standalone PR so it's clearly separated from any other changes one might be trying to debug.

for more, see the extant DTP documentation on developer setup: https://github.com/dtinit/data-transfer-project/blob/badda9bb520e59cd13227e2f4a9e4189b0bc7e59/Documentation/Developer.md#setup-formatting (I'm not using intellij, but google-java-format exists in every editor I've used, so the instructions should still stand).