### PR TITLE
workaround annoying .attach_pid1234 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,10 @@ Thumbs.db
 
 app_data/
 
+# Ignore JDK 11 bug's stray files: https://bugs.openjdk.org/browse/JDK-8214300
+# (fixed in JDK 12).
+# TODO remove this gitignore when this codebase uses JDK 12+
+**/.attach_pid*
+
 **/**/.out
 **/**/**/protogen


### PR DESCRIPTION
example of this really coming up: https://github.com/dtinit/data-transfer-project/pull/1401#pullrequestreview-2482420787

and then it's continued to happen all day for me.