### PR TITLE
noop(preventing bugs) keep assertion after switch

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftApiResponse.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftApiResponse.java
@@ -34,7 +34,7 @@ import org.datatransferproject.spi.transfer.types.PermissionDeniedException;
  *
  * <p>Example usage error handling workflow:
  *
- * <pre>
+ * <pre>{@code
  * MicrosoftApiResponse resp = someServerCall();
  * Optional<RecoverableState> recovery = resp.recoverableState();
  * if (recovery.isPresent()) {
@@ -48,7 +48,7 @@ import org.datatransferproject.spi.transfer.types.PermissionDeniedException;
  *   }
  * }
  * resp.throwDtpException(); // or returnConvertDtpException might help
- * </pre>
+ * }</pre>
  */
 @AutoValue
 public abstract class MicrosoftApiResponse {
@@ -163,9 +163,8 @@ public abstract class MicrosoftApiResponse {
             "Microsoft destination storage limit reached", toIoException(message));
       case FATAL_STATE_FATAL_UNSPECIFIED:
         throw toIoException(String.format("%s: %s", CAUSE_PREFIX_UNRECOGNIZED_EXCEPTION, message));
-      default:
-        throw new AssertionError("exhaustive switch");
     }
+    throw new AssertionError("exhaustive switch");
   }
 
   /**
@@ -208,6 +207,8 @@ public abstract class MicrosoftApiResponse {
   }
 
   /**
+   * Produce {@link toIoException} with a message used to construct the exception's cause.
+   *
    * @param message The cause-message one might expect with a {@link java.lang.Exception}
    *     construction.
    */

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporter.java
@@ -155,7 +155,6 @@ public class MicrosoftMediaImporter
   }
 
   /** Returns a folder ID after asking Microsoft APIs to allocate one for the given album. */
-  @SuppressWarnings("unchecked")
   private String createOneDriveFolder(MediaAlbum album)
       throws IOException, CopyExceptionWithFailureReason {
     Map<String, Object> rawFolder = new LinkedHashMap<>();
@@ -377,11 +376,11 @@ public class MicrosoftMediaImporter
    *
    * <p>Example usage:
    *
-   * <pre>
+   * <pre>{@code
    * MicrosoftApiResponse resp = tryWithCredsOrFail(request, "creating a folder");
    * checkState(resp.isOkay(), "bug: tryWithCredsOrFail() should have returne healthy resp");
    * // ...carry on as normal with business logic...
-   * </pre>
+   * }</pre>
    *
    * @param causeMessage a contextual message to include as the root cause/context when throwing a
    *     DTP excption.
@@ -401,9 +400,8 @@ public class MicrosoftMediaImporter
               String.format(
                   "bug! microsoft server needs token refresh immediately after a refreshing: %s",
                   causeMessage));
-        default:
-          throw new AssertionError("exhaustive switch");
       }
+      throw new AssertionError("exhaustive switch");
     }
     return response.returnConvertDtpException(
         String.format(
@@ -417,10 +415,10 @@ public class MicrosoftMediaImporter
    *
    * <p>Example usage:
    *
-   * <pre>
+   * <pre>{@code
    * @Nonnull String folderId = tryWithCredsOrFail(request, "folderId", "creating a folder");
    * // ...carry on as normal with business logic...
-   * </pre>
+   * }</pre>
    *
    * @param jsonResponseKey the top-level value to extract from the response body.
    * @param causeMessage a contextual message to include as the root cause/context when throwing a


### PR DESCRIPTION
internal linter pointed out the assertion being on the `default` case prevents javac from telling us when a switch is insufficient.