### PR TITLE
fix broken fake with extant in-memory option

### DIFF
--- a/portability-test-utilities/src/main/java/org/datatransferproject/test/types/FakeIdempotentImportExecutor.java
+++ b/portability-test-utilities/src/main/java/org/datatransferproject/test/types/FakeIdempotentImportExecutor.java
@@ -1,70 +1,17 @@
 package org.datatransferproject.test.types;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
-import org.datatransferproject.types.transfer.errors.ErrorDetail;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.InMemoryIdempotentImportExecutor;
 
-public class FakeIdempotentImportExecutor implements IdempotentImportExecutor {
+/** Unit-test friendly, fully-functional IdempotentImportExecutor, entirely in memory. */
+// TODO migrate tests constructing InMemoryIdempotentImportExecutor to this class to avoid future
+// noise where we have to touch every test (should InMemoryIdempotentImportExecutor start doing
+// something unfriendly to tests).
+public class FakeIdempotentImportExecutor extends InMemoryIdempotentImportExecutor {
+  // TODO figure out how to get Gradle to let us mock(Monitor.class) ourselves here?
+  private static final Monitor fakeMonitor = new Monitor() {};
 
-  private HashMap<String, Serializable> knownValues = new HashMap<>();
-
-  @Override
-  public <T extends Serializable> T executeAndSwallowIOExceptions(
-      String idempotentId, String itemName, Callable<T> callable) throws Exception {
-    try {
-      return executeOrThrowException(idempotentId, itemName, callable);
-    } catch (IOException e) {
-      return null;
-    }
-  }
-
-  @Override
-  public <T extends Serializable> T executeOrThrowException(
-      String idempotentId, String itemName, Callable<T> callable) throws Exception {
-    if (knownValues.containsKey(idempotentId)) {
-      System.out.println("Using cached key " + idempotentId + " from cache");
-      return (T) knownValues.get(idempotentId);
-    }
-    try {
-      T result = callable.call();
-      knownValues.put(idempotentId, result);
-      System.out.println("Storing key " + idempotentId + " in cache");
-      return result;
-    } catch (Exception e) {
-      throw e;
-    }
-  }
-
-  @Override
-  public <T extends Serializable> T getCachedValue(String idempotentId) {
-    if (!knownValues.containsKey(idempotentId)) {
-      throw new IllegalArgumentException(
-          idempotentId
-              + " is not a known key, known keys: "
-              + Joiner.on(", ").join(knownValues.keySet()));
-    }
-    return (T) knownValues.get(idempotentId);
-  }
-
-  @Override
-  public boolean isKeyCached(String idempotentId) {
-    return knownValues.containsKey(idempotentId);
-  }
-
-  @Override
-  public Collection<ErrorDetail> getErrors() {
-    return ImmutableList.of();
-  }
-
-  @Override
-  public void setJobId(UUID jobId) {
-    // We deliberately do nothing here as this class is Fake and not behaviour which needs to be faked
+  public FakeIdempotentImportExecutor() {
+    super(FakeIdempotentImportExecutor.fakeMonitor);
   }
 }


### PR DESCRIPTION
caused us some headscratching: I was sure there must've been a good reason for the fake impl _and_ the in-memory impl, but this patch seems to pass all tests, so I think that's good enough.