### PR TITLE
gradle need not depend on ./git/ (vcs)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,7 +215,7 @@ def configurePublication(Project project) {
 def setGitVersion() {
     def repo = new RepositoryBuilder().setGitDir(new File(project.rootDir, '/.git')).readEnvironment().build()
 
-    def version = repo.findRef('HEAD').getObjectId().name
+    def version = repo ? 'unknown vcs state' : repo.findRef('HEAD').getObjectId().name
     def clean = Git.wrap(repo).status().call().isClean()
     ext.gitVersion = version + (clean ? '' : '.modified')
 }


### PR DESCRIPTION
for example, a download/tar of a repo often doesn't have a vcs. it's quite common to just fall back to "unknown", so I'm doing that.

without this commit, you cannot build or test this project:

```sh
$ ./gradlew --watch-fs --continuous --console=rich -Dorg.gradle.java.home=/usr/lib/jvm/java-11-openjdk-amd64 test
<-------------> 0% CONFIGURING [17ms]
> Loading projects

FAILURE: Build failed with an exception.

* Where:
Build file 'build.gradle' line: 218

* What went wrong:
A problem occurred evaluating root project 'org.datatransferproject'.
> Cannot invoke method getObjectId() on null object

* Try:
Run with --stacktra
> Configure project :
Node installation: local, Cloud type: local

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9.2/userguide/command_line_interface.html#sec:command_line_warnings

Exiting continuous build as no executed tasks declared file system inputs.
<-------------> 0% WAITING
> IDLE
https://help.gradle.org
```