### PR TITLE
fix: illegalstatexception: reading responses that are always closed

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporter.java
@@ -35,7 +35,6 @@ import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import okhttp3.Response;
 import org.apache.commons.lang3.tuple.Pair;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.api.transport.JobFileStream;
@@ -341,11 +340,11 @@ public class MicrosoftMediaImporter
   /** Low-level API call used by other helpers: prefer {@link tryWithCreds} instead. */
   private MicrosoftApiResponse sendMicrosoftRequest(Request.Builder requestBuilder)
       throws IOException {
-    try (Response response = client.newCall(requestBuilder.build()).execute()) {
-      return MicrosoftApiResponse.ofResponse(
-          checkNotNull(
-              response, "null microsoft server response for %s", requestBuilder.build().url()));
-    }
+    return MicrosoftApiResponse.ofResponse(
+        checkNotNull(
+            client.newCall(requestBuilder.build()).execute(),
+            "null microsoft server response for %s",
+            requestBuilder.build().url()));
   }
 
   /**


### PR DESCRIPTION
while we're at it, just take what we need (unmarshal into a string) and close it ourselves, letting caller stop worrrying about this closeable.

while we're he we *also* cleanup all our unit tests so they use real Response objects, and stop mocking it. (This is the same recent codehealth change made to stop using ResponseBody mocks, and use the real things). Not interacting with the real OkHTTP API was part of what made this issue invisible before.