### PR TITLE
fix(microsoft): 401s only sometimes correctly classified

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftApiResponse.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftApiResponse.java
@@ -150,8 +150,12 @@ public abstract class MicrosoftApiResponse {
    * Whether the response health is neither OK nor outright error, but merely requires a token
    * refresh (then a retry).
    */
+  // See
+  // https://learn.microsoft.com/en-us/graph/resolve-auth-errors#401-unauthorized-error-is-your-token-valid
+  // And Microsoft's Java SDK to interact with these APIs:
+  // https://github.com/AzureAD/microsoft-authentication-library-for-java
   public boolean isTokenRefreshRequired() {
-    return httpStatus() == 401;
+    return httpStatus() == 401 && bodyContains("InvalidAuthenticationToken");
   }
 
   /** Whether response is of an unrecoverable error, indicating {@link throwDtpException} usage. */

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporterTest.java
@@ -173,7 +173,7 @@ public class MicrosoftMediaImporterTest {
                     r.url()
                         .toString()
                         .equals("https://www.baseurl.com/v1.0/me/drive/special/photos/children")));
-    Response response = fakeResponse(403, "Access Denied", "{\"id\": \"id1\"}").build();
+    Response response = fakeErrorResponse(403, "Access Denied", "{\"id\": \"id1\"}").build();
     when(call.execute()).thenReturn(response);
 
     assertThrows(
@@ -201,7 +201,8 @@ public class MicrosoftMediaImporterTest {
                         .toString()
                         .equals("https://www.baseurl.com/v1.0/me/drive/special/photos/children")));
     Response response =
-        fakeResponse(507, "" /*httpMessage*/, "{\"message\": \"Insufficient Space Available\"}")
+        fakeErrorResponse(
+                507, "" /*httpMessage*/, "{\"message\": \"Insufficient Space Available\"}")
             .build();
     when(call.execute()).thenReturn(response);
 
@@ -230,7 +231,7 @@ public class MicrosoftMediaImporterTest {
                         .toString()
                         .equals("https://www.baseurl.com/v1.0/me/drive/special/photos/children")));
     Response response =
-        fakeResponse(
+        fakeErrorResponse(
                 500,
                 "" /*httpMessage*/,
                 "{\"message\": \"Hippo is the best dog, not a real-world response\"}")
@@ -320,6 +321,11 @@ public class MicrosoftMediaImporterTest {
     ImportResult result = importer.importItem(uuid, executor, authData, data);
     verify(client, atLeast(albums.size() + photos.size())).newCall(any());
     assertThat(result).isEqualTo(ImportResult.OK);
+  }
+
+  private static Response.Builder fakeErrorResponse(
+      int statusCode, String httpMessage, String jsonErrorValue) {
+    return fakeResponse(statusCode, httpMessage, String.format("{ \"error\": %s ", jsonErrorValue));
   }
 
   private static Response.Builder fakeResponse(


### PR DESCRIPTION
regression coverage: without the fix in MicrosoftApiResponse.java this new test's state captures `isTokenRefreshRequired()` erroneously returning true:

```
MicrosoftApiResponseTest > testDestinationFull PASSED

MicrosoftApiResponseTest > testUnrecognized401 FAILED
    java.lang.AssertionError: The subject was expected to be false, but was true
        at org.datatransferproject.transfer.microsoft.MicrosoftApiResponseTest.testUnrecognized401(MicrosoftApiResponseTest.java:130)

MicrosoftApiResponseTest > testBytesOnClosedResponse PASSED

MicrosoftApiResponseTest > testOkay PASSED

MicrosoftApiResponseTest > testInvalidTokenDetection PASSED

MicrosoftApiResponseTest > testErrorPermission PASSED

MicrosoftApiResponseTest > testErrorUnknown PASSED

MicrosoftMediaImporterTest > testImportItemAllSuccess PASSED

MicrosoftMediaImporterTest > testImportItemPermissionDenied PASSED

MicrosoftMediaImporterTest > testImportInsufficientStorage PASSED

MicrosoftMediaImporterTest > testCleanAlbumNames PASSED

MicrosoftMediaImporterTest > testImportUnrecognizedError PASSED
```

nit: while I'm here, properly nest the response-bodies in our unit tests' examples. for now it doesn't matter because the code has always just scraped across the body instead of parsing it, but just want to avoid confusion going forward.