### PR TITLE
fixes microsoft server _sometimes_ failing due to un-required token

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaImporter.java
@@ -303,17 +303,29 @@ public class MicrosoftMediaImporter
     return new Request.Builder().url(createSessionUrl);
   }
 
-  // Uploads a single DataChunk to an upload URL
-  // PUT to {photoUploadUrl}
-  // HEADERS
-  // Content-Length: {chunk size in bytes}
-  // Content-Range: bytes {begin}-{end}/{total size}
-  // body={bytes}
+  /**
+   * Uploads a single DataChunk to an upload URL {@code photoUploadUrl} via PUT
+   * request with this composition:
+   * <pre>{@code
+   *  HEADERS
+   *  Content-Length: $CHUNK_SIZE_IN_BYTES
+   *  Content-Range: bytes $BEGIN_INDEX-$END_INDEX/$TOTAL_SIZE
+   *  body=$BYTES
+   * }</pre>
+   *
+   * <p>NOTE: an access token is purposely not incluced per Microsoft SDK's own instructions:
+   * https://learn.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0#remarks
+   *
+   *
+   * <p>See also:
+   * <ul>
+   * <li>https://learn.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0#upload-bytes-to-the-upload-session
+   * </ul>
+   */
   private MicrosoftApiResponse uploadChunk(
       DataChunk chunk, String photoUploadUrl, long totalFileSize, String mediaType)
       throws IOException, DestinationMemoryFullException, PermissionDeniedException {
     Request.Builder uploadRequestBuilder = new Request.Builder().url(photoUploadUrl);
-    uploadRequestBuilder.header("Authorization", "Bearer " + credential.getAccessToken());
 
     // put chunk data in
     RequestBody uploadChunkBody =


### PR DESCRIPTION
we're sometimes seeing the following microsoft server response at the `uploadChunk()` callsite:

```
MicrosoftApiResponse{httpStatus=401, httpMessage=, body=Optional[
{
    "error": {
        "code": "unauthenticated",
        "message": "Unauthenticated"
    }
}
]}
```

which according to their documentation is because we simply aren't supposed to send the token during our chunked byte-upload sequence (PUT), but only during our createSession (POST) call at the start:

> If you include the Authorization header when issuing the `PUT` call,
> it may result in an `HTTP 401 Unauthorized` response. Only send the
> Authorization header and bearer token when issuing the `POST` during
> the first step. Don't include it when you issue the `PUT` call.


-- https://learn.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0#remarks