### PR TITLE
ci: add conventional commit lint check to PR titles

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,17 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+   types: [opened, synchronize, edited]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Install commitizen"
+        run: pip install --user -U commitizen
+      - name: "Lint the PR title"
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: echo "${TITLE}" | cz check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,11 @@ that's welcome).
 
 All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose.
+
+### PR Titles
+
+To automate releases we require that PRs are titled according to
+[conventional commits](https://conventionalcommits.org); i.e. that they
+are tagged like `fix: handle exception XYZ correctly`, or
+`feat: implement new video exporter`. See the conventional commits documentation
+for more details.


### PR DESCRIPTION
In preparation for automating the release process, adds a check to start linting PR titles based on [conventional commits](https://conventionalcommits.org).