### PR TITLE
ci(dependabot): use conventional commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     # Always increase the version requirement
     # to match the new version.
     versioning-strategy: increase
+    commit-message:
+      prefix: "fix"
+      prefix-development: "build"
+      include: "scope"


### PR DESCRIPTION
Makes dependabot use conventional-commit style PR titles