### PR TITLE
feat: Destination Full support for Generic Importers 

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-generic/README.md
+++ b/extensions/data-transfer/portability-data-transfer-generic/README.md
@@ -753,3 +753,4 @@ Content-Type: application/json
 }
 ```
 The worker will pause the job and won't retry in such scenario.
+Some exporters also support the ability to retry transfers after user frees up space in the destination.

--- a/extensions/data-transfer/portability-data-transfer-generic/README.md
+++ b/extensions/data-transfer/portability-data-transfer-generic/README.md
@@ -709,7 +709,7 @@ If there is an error importing an item on any endpoint, the relevant HTTP respon
 }
 ```
 
-The combination of the HTTP response code and `error` field can be used to encode for specific failure modes; see [Token Refresh](#token-refresh) below.
+The combination of the HTTP response code and `error` field can be used to encode for specific failure modes; see [Token Refresh](#token-refresh) & [Destination Full](#destination-full) below.
 
 ## Authentication and Authorization
 

--- a/extensions/data-transfer/portability-data-transfer-generic/README.md
+++ b/extensions/data-transfer/portability-data-transfer-generic/README.md
@@ -734,3 +734,22 @@ Content-Type: application/json
 ```
 
 The worker will request a token refresh through the standard OAuth refresh token flow.
+
+### Destination Full
+
+If the destination is unable to accept additional data for user due to capacity constrain or other limitations,
+the POST APIs should throw `413 Payload Too Large` error to avoid unnecessary data transfer attempts.
+
+`error` field should strictly be set to `destination_full` to indicate that the destination storage is full.
+
+Example error response:
+
+```
+HTTP/1.1 413 Payload Too Large
+Content-Type: application/json
+{
+  "error": "destination_full",
+  "error_description": "The destination storage is full"
+}
+```
+The worker will pause the job and won't retry in such scenario.

--- a/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/GenericFileImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/GenericFileImporter.java
@@ -3,6 +3,7 @@ package org.datatransferproject.datatransfer.generic;
 import static java.lang.String.format;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Optional;
@@ -16,6 +17,7 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.connection.ConnectionProvider;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputStreamWrapper;
+import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
 import org.datatransferproject.spi.transfer.types.InvalidTokenException;
 import org.datatransferproject.types.common.models.ContainerResource;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
@@ -43,7 +45,7 @@ public class GenericFileImporter<C extends ContainerResource, R> extends Generic
   @Override
   public boolean importSingleItem(
       UUID jobId, TokensAndUrlAuthData authData, ImportableData<R> dataItem)
-      throws IOException, InvalidTokenException {
+      throws IOException, InvalidTokenException, DestinationMemoryFullException {
     if (dataItem instanceof ImportableFileData) {
       return importSingleFileItem(jobId, authData, (ImportableFileData<R>) dataItem);
     } else {
@@ -53,7 +55,7 @@ public class GenericFileImporter<C extends ContainerResource, R> extends Generic
 
   private <T> boolean importSingleFileItem(
       UUID jobId, AuthData authData, ImportableFileData<R> data)
-      throws IOException, InvalidTokenException {
+      throws IOException, InvalidTokenException, DestinationMemoryFullException {
     InputStreamWrapper wrapper = connectionProvider.getInputStreamForItem(jobId, data.getFile());
     File tempFile =
         dataStore.getTempFileFromInputStream(wrapper.getStream(), data.getFile().getName(), null);

--- a/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/GenericFileImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/GenericFileImporter.java
@@ -3,7 +3,6 @@ package org.datatransferproject.datatransfer.generic;
 import static java.lang.String.format;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Optional;

--- a/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/GenericImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/GenericImporter.java
@@ -115,6 +115,7 @@ public class GenericImporter<C extends ContainerResource, R>
       TokensAndUrlAuthData initialAuthData,
       C data)
       throws Exception {
+    
     OAuthTokenManager tokenManager =
         jobTokenManagerMap.computeIfAbsent(
             jobId,

--- a/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/GenericImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/GenericImporter.java
@@ -31,6 +31,7 @@ import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportE
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.ImportResult.ResultType;
 import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
 import org.datatransferproject.spi.transfer.types.InvalidTokenException;
 import org.datatransferproject.types.common.models.ContainerResource;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
@@ -115,7 +116,7 @@ public class GenericImporter<C extends ContainerResource, R>
       TokensAndUrlAuthData initialAuthData,
       C data)
       throws Exception {
-    
+
     OAuthTokenManager tokenManager =
         jobTokenManagerMap.computeIfAbsent(
             jobId,
@@ -131,7 +132,7 @@ public class GenericImporter<C extends ContainerResource, R>
     return new ImportResult(ResultType.OK);
   }
 
-  boolean parseResponse(Response response) throws IOException, InvalidTokenException {
+  boolean parseResponse(Response response) throws IOException, InvalidTokenException, DestinationMemoryFullException {
     if (response.code() >= 400) {
       byte[] body = response.body().bytes();
       ErrorResponse error;
@@ -147,6 +148,10 @@ public class GenericImporter<C extends ContainerResource, R>
 
       if (response.code() == 401 && error.getError().equals("invalid_token")) {
         throw new InvalidTokenException(error.toString(), null);
+      } if (response.code() == 413 && error.getError().equals("destination_full")) {
+        throw new DestinationMemoryFullException(
+            String.format("Generic importer failed with code (%s)", response.code()),
+            new RuntimeException("destination_full"));
       } else {
         throw new IOException(format("Error (%d) %s", response.code(), error.toString()));
       }
@@ -158,7 +163,7 @@ public class GenericImporter<C extends ContainerResource, R>
   }
 
   boolean importSingleItem(UUID jobId, TokensAndUrlAuthData authData, ImportableData<R> dataItem)
-      throws IOException, InvalidTokenException {
+      throws IOException, InvalidTokenException, DestinationMemoryFullException {
     Request request =
         new Request.Builder()
             .url(endpoint)

--- a/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/auth/OAuthTokenManager.java
+++ b/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/auth/OAuthTokenManager.java
@@ -20,8 +20,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.transfer.types.CopyExceptionWithFailureReason;
-import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
 import org.datatransferproject.spi.transfer.types.InvalidTokenException;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;

--- a/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/auth/OAuthTokenManager.java
+++ b/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/auth/OAuthTokenManager.java
@@ -20,6 +20,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.transfer.types.CopyExceptionWithFailureReason;
+import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
 import org.datatransferproject.spi.transfer.types.InvalidTokenException;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
@@ -66,8 +68,8 @@ class RefreshTokenResponse {
  */
 public class OAuthTokenManager {
   @FunctionalInterface
-  public interface FunctionRequiringAuthData<T> {
-    public T execute(TokensAndUrlAuthData authData) throws IOException, InvalidTokenException;
+  public interface FunctionRequiringAuthData<T, Ex extends Exception> {
+    public T execute(TokensAndUrlAuthData authData) throws Ex, InvalidTokenException;
   }
 
   AppCredentials appCredentials;
@@ -151,8 +153,8 @@ public class OAuthTokenManager {
    * @throws InvalidTokenException if {@code f} throws an {@link InvalidTokenException} after the
    *     access token has been refreshed
    */
-  public <T> T withAuthData(FunctionRequiringAuthData<T> f)
-      throws IOException, InvalidTokenException {
+  public <T, Ex extends Exception> T withAuthData(FunctionRequiringAuthData<T, Ex> f)
+      throws Ex, InvalidTokenException, IOException {
     try {
       return f.execute(authData);
     } catch (InvalidTokenException e) {

--- a/extensions/data-transfer/portability-data-transfer-generic/src/test/java/org/datatransferproject/datatransfer/generic/GenericImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-generic/src/test/java/org/datatransferproject/datatransfer/generic/GenericImporterTest.java
@@ -1,7 +1,9 @@
 package org.datatransferproject.datatransfer.generic;
 
 import static java.lang.String.format;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -31,10 +33,10 @@ import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
 public class GenericImporterTest {
-  @Parameter public String importerClass;
-  private MockWebServer webServer;
   private final Monitor monitor = new Monitor() {};
   private final TemporaryPerJobDataStore dataStore = new TemporaryPerJobDataStore() {};
+  @Parameter public String importerClass;
+  private MockWebServer webServer;
 
   @Parameters(name = "{0}")
   public static Collection<String> strings() {


### PR DESCRIPTION
Fixes #1424.


Generic importers will throw `DestinationMemoryFullException`(which extends `CopyExceptionWithFailureReason`) when any of the import post API implemented by client throws error with code: `413` & error: `destination_full` 