### PR TITLE
ci: use Github App token to push changelog and tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,23 @@ jobs:
     outputs:
       version: ${{ steps.cz.outputs.version }}
     steps:
+      # To push to the repo an bypass the PR requirement, we need
+      # to use an App since the default github actions-provided token
+      # can't be configured to bypass requirements.
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch tags, which are required to calculate the new version
-          token: "${{ secrets.GITHUB_TOKEN }}"
+          token: ${{ steps.app-token.outputs.token }}
       - id: cz
         name: "Generate Changelog and Tag"
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
   release:
     needs: bump_version
     runs-on: ubuntu-latest

--- a/Documentation/Publishing.md
+++ b/Documentation/Publishing.md
@@ -18,6 +18,8 @@ Commitizen is a tool that supports automatically incrementing SemVer version num
 
 ### Automated Publishing
 
+The `bump_version` job uses the Commitizen action to generate a changelog and bump version files by pushing and tagging a new commit on the main branch. To push to the repo requires a token with more privileges than the default Github Actions runner is given access to because of our branch protection rules, so we have a Github App called 'DTP Release Bot' that this job is configured to run as.
+
 Using the `maven` and `signing` gradle plugins adds the `sign` and `uploadArchives` targets, which together automate the process of publishing to Maven Central based on our configuration in `build.gradle`. \
 The `release` job in the Github action runs these targets, using environment variables to inject secret values like GPG keys and the OSSRH User Token required for publishing.
 


### PR DESCRIPTION
To push the changelog and tag we need to bypass the branch rules, which will require the set-up of a Github App so we can mint a higher-privileged token in the pipeline.