### PR TITLE
ci: release without committing to main branch

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -3,8 +3,5 @@ name = "cz_conventional_commits"
 tag_format = "v$version"
 version_scheme = "semver"
 version_provider = "scm"
-update_changelog_on_bump = true
-version_files = [
-  "gradle.properties:projectVersion="
-]
+update_changelog_on_bump = false
 changelog_start_rev = "v1.0.0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,17 +17,22 @@ jobs:
     runs-on: ubuntu-latest
     name: "Bump version"
     outputs:
-      version: ${{ steps.cz.outputs.version }}
+      version: ${{ steps.tag.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch tags, which are required to calculate the new version
           token: "${{ secrets.GITHUB_TOKEN }}"
-      - id: cz
-        name: "Generate Changelog and Tag"
-        uses: commitizen-tools/commitizen-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Install commitizen"
+        run: pip install --user -U commitizen
+      - id: tag
+        name: "Tag release"
+        run: |
+          VERSION=$(cz bump --get-next)
+          TAG="v${VERSION}"
+          git tag "${TAG}"
+          git push origin "${TAG}" --tags
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
   release:
     needs: bump_version
     runs-on: ubuntu-latest
@@ -35,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.bump_version.outputs.version }}
+          ref: "v${{ needs.bump_version.outputs.version }}"
       - name: "Set up JDK"
         uses: actions/setup-java@v4
         with:
@@ -48,5 +53,6 @@ jobs:
           GRADLE_SIGNING_PASSWORD: "${{ secrets.GRADLE_SIGNING_PASSWORD }}"
           OSSRH_USERNAME: "${{ secrets.OSSRH_USERNAME }}"
           OSSRH_PASSWORD: "${{ secrets.OSSRH_PASSWORD }}"
+          RELEASE_VERSION: "${{ needs.bump_version.outputs.version }}"
         # Exclude client-rest as it's not part of the java release
         run: ./gradlew clean build sign uploadArchives --exclude-task :client-rest:uploadArchives

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           TAG="v${NEW_VERSION}"
           git tag "${TAG}" &&
             git push origin "${TAG}" --tags &&
-            echo "version=${NEW_VERSION}" | tee "$GITHUB_OUTPUT"
+            echo "version=${NEW_VERSION}" | tee -a "$GITHUB_OUTPUT"
   release:
     needs: bump_version
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,17 @@ jobs:
           fetch-depth: 0  # Fetch tags, which are required to calculate the new version
           token: "${{ secrets.GITHUB_TOKEN }}"
       - name: "Install commitizen"
-        run: pip install --user -U commitizen
-      - id: tag
-        name: "Tag release"
         run: |
-          VERSION=$(cz bump --get-next)
-          TAG="v${VERSION}"
-          git tag "${TAG}"
-          git push origin "${TAG}" --tags
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          pip install --user -U commitizen &&
+            cz version --verbose
+      - id: tag
+        name: "Release: Publish new semver Git Tag"
+        run: |
+          NEW_VERSION=$(cz bump --get-next) || exit 1
+          TAG="v${NEW_VERSION}"
+          git tag "${TAG}" &&
+            git push origin "${TAG}" --tags &&
+            echo "version=${NEW_VERSION}" | tee "$GITHUB_OUTPUT"
   release:
     needs: bump_version
     runs-on: ubuntu-latest

--- a/Documentation/Publishing.md
+++ b/Documentation/Publishing.md
@@ -14,7 +14,7 @@ The action contains two jobs; one to bump the version number of the DTP packages
 
 DTP uses [Semantic Versioning](https://semver.org/) for published packages. We also enforce [Conventional Commits](https://conventionalcommits.org/) on the `master` branch through the `.github/workflows/commitlint.yml` Github action, which lets us automatically calculate version numbers.
 
-Commitizen is a tool that supports automatically incrementing SemVer version numbers based on git commit history. Our usage of Commitizen is configured in `.cz.toml`, and is used in a Github action to automatically tag the new version in git.
+Commitizen is a tool that supports automatically incrementing SemVer version numbers based on git commit history. Our usage of Commitizen is configured in `.cz.toml`, and is used in a Github action to automatically tag the new version in git and publish to maven (per "automated publishing" section of this doc).
 
 ### Automated Publishing
 

--- a/Documentation/Publishing.md
+++ b/Documentation/Publishing.md
@@ -14,7 +14,7 @@ The action contains two jobs; one to bump the version number of the DTP packages
 
 DTP uses [Semantic Versioning](https://semver.org/) for published packages. We also enforce [Conventional Commits](https://conventionalcommits.org/) on the `master` branch through the `.github/workflows/commitlint.yml` Github action, which lets us automatically calculate version numbers.
 
-Commitizen is a tool that supports automatically incrementing SemVer version numbers based on git commit history. Our usage of Commitizen is configured in `.cz.toml`, and uses the `commitizen-tools/commitizen-action` Github action to automatically bump the package version number and to tag the new version in git.
+Commitizen is a tool that supports automatically incrementing SemVer version numbers based on git commit history. Our usage of Commitizen is configured in `.cz.toml`, and is used in a Github action to automatically tag the new version in git.
 
 ### Automated Publishing
 
@@ -38,7 +38,6 @@ If for some reason you need to publish manually, the steps are detailed below.
 
 ### 1. Setting properties
  First you must set the necessary properties in [gradle.properties](../gradle.properties). These are:
- - `projectVersion` - this is the new version you wish to publish.
  - `ossrhUsername` & `ossrhPassword` - These are your Sonatype [User Token](https://central.sonatype.org/publish/generate-token/#generate-a-token-on-ossrh-sonatype-nexus-repository-manager-servers) credentials. Your account must have been granted publishing permissions. Permissions are managed manually by Sonatype - see [Sonatype's documentation](https://central.sonatype.org/register/legacy/) for details.
  - `signing.keyId` - The GPG key being used for signing the artifacts. (More information about setting up GPG keys can be found [here](https://central.sonatype.org/publish/requirements/gpg/))
  - `signing.password` - The password for that GPG private key.
@@ -48,10 +47,10 @@ If for some reason you need to publish manually, the steps are detailed below.
 Make sure that the artifacts are building and running correctly. For example run the worker in the Docker container, see [Running Locally](RunningLocally.md) for instructions.
 
 ### 3. Sign and upload
-To sign and publish the artifacts run the following Gradle command:
+To sign and publish the artifacts run the following Gradle command, replacing `<version>` with the new version number:
 
 ```
-./gradlew sign uploadArchives --exclude-task :client-rest:uploadArchives
+RELEASE_VERSION=<version> ./gradlew sign uploadArchives --exclude-task :client-rest:uploadArchives
 ```
 
 We exclude the client-rest archives as these are not a Java package.

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ configure(sourceProjects()) {
     apply plugin: 'idea'
 
     group = "${projectGroup}"
-    version = "${projectVersion}"
+    version = System.getenv('RELEASE_VERSION')
 
     sourceCompatibility = 11
 
@@ -108,40 +108,6 @@ configure(sourceProjects()) {
     task javadocJar(type: Jar) {
         classifier = 'javadoc'
         from "../notice/javadoc/README.md"
-    }
-}
-
-task bumpPatchVersion {
-    doLast {
-        println "Current version: ${projectVersion}"
-        def (major, minor, patch) = projectVersion.tokenize(['.-'])
-        setSnapshotVersion(major, minor, patch.toInteger() + 1)
-    }
-}
-
-task bumpMinorVersion {
-    doLast {
-        println "Current version: ${projectVersion}"
-        def (major, minor, patch) = projectVersion.tokenize(['.-'])
-        setSnapshotVersion(major, minor.toInteger() + 1, patch)
-    }
-}
-
-task bumpMajorVersion {
-    doLast {
-        println "Current version: ${projectVersion}"
-        def (major, minor, patch) = projectVersion.tokenize(['.-'])
-        setSnapshotVersion(major.toInteger() + 1, minor, patch)
-    }
-}
-
-def setSnapshotVersion(major, minor, patch) {
-    def newVersion = "$major.$minor.$patch-SNAPSHOT"
-
-    println "New version: ${newVersion}"
-    ant.propertyfile(
-            file: "gradle.properties") {
-        entry(key: "projectVersion", value: newVersion)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 projectGroup=org.datatransferproject
-projectVersion=1.0.4
 annotationApiVersion=1.2
 autoValueVersion=1.9
 commonsLangVersion=3.4

--- a/portability-transfer/build.gradle
+++ b/portability-transfer/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 group = "${projectGroup}"
-version = "${projectVersion}"
+version = System.getenv("RELEASE_VERSION")
 
 description = """Portability Worker"""
 


### PR DESCRIPTION
Committing to the master branch isn't allowed from github actions because of our branch protection rules. There's no easy way to allow github actions to bypass this.

As a workaround, skip all the parts of the release that needed to commit to the repo. This means moving the version config to an environment variable, which shouldn't be an issue, and using git tags as the source of truth.