### PR TITLE
fix(generic): make ContainerSerializer interface public

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/ContainerSerializer.java
+++ b/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/ContainerSerializer.java
@@ -1,0 +1,8 @@
+package org.datatransferproject.datatransfer.generic;
+
+import org.datatransferproject.types.common.models.ContainerResource;
+
+@FunctionalInterface
+public interface ContainerSerializer<C extends ContainerResource, R> {
+  public Iterable<ImportableData<R>> apply(C containerResource);
+}

--- a/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/GenericImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/GenericImporter.java
@@ -37,11 +37,6 @@ import org.datatransferproject.types.common.models.ContainerResource;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
-@FunctionalInterface
-interface ContainerSerializer<C extends ContainerResource, R> {
-  public Iterable<ImportableData<R>> apply(C containerResource);
-}
-
 public class GenericImporter<C extends ContainerResource, R>
     implements Importer<TokensAndUrlAuthData, C> {
 


### PR DESCRIPTION
The `ContainerSerializer` interface needs to be public for any package other than `org.datatranfserproject.datatransfer.generic` to be able to instantiate a `GenericImporter`.
We want to implement a custom `GenericTransferExtension` that can load from a database rather than packaged config file, so need to be able to instantiate `GenericImporter`s from a different package.