### PR TITLE
fix: prevent crashes due to off-chance strings are really format-looking

### DIFF
--- a/portability-api-launcher/src/main/java/org/datatransferproject/launcher/monitor/ConsoleMonitor.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/launcher/monitor/ConsoleMonitor.java
@@ -117,7 +117,7 @@ public class ConsoleMonitor implements Monitor {
 
     // Write to standard error, as these are debug logs for which any buffering
     // won't help us at all.
-    System.err.format(builder.toString());
+    System.err.println(builder.toString());
   }
 
   /**


### PR DESCRIPTION
fix: prevent crashes due to off-chance strings will _actually_ have `%` chars inside, looking like a format string.

background-context: the last change (#1425) to this line was intended to switch from `out` to `err`, not to change the method of choice (that was just an accident of habitual-typing).

This was able to sometimes cause a crash on an invocation to log because `java.util.Formatter.parse` would see a formatter symbol (`%`) then try to make sense of it or match it to another arg (of which we pass no other args). All a mistake anyway: we didn't want `format()` to begin with.