### PR TITLE
fix(generic): don't fail on unknown properties while deserialising RefreshTokenResponse

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/auth/OAuthTokenManager.java
+++ b/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/auth/OAuthTokenManager.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -97,6 +98,7 @@ public class OAuthTokenManager {
     this.client = client;
     this.monitor = monitor;
     this.om.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    this.om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   }
 
   private TokensAndUrlAuthData refreshToken() throws IOException {
@@ -157,7 +159,7 @@ public class OAuthTokenManager {
       return f.execute(authData);
     } catch (InvalidTokenException e) {
       if (authData.getRefreshToken() == null || authData.getRefreshToken().isEmpty()) {
-        throw e;
+        throw new InvalidTokenException("Refresh token not present", e.getCause());
       }
 
       this.authData = refreshToken();

--- a/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/auth/OAuthTokenManager.java
+++ b/extensions/data-transfer/portability-data-transfer-generic/src/main/java/org/datatransferproject/datatransfer/generic/auth/OAuthTokenManager.java
@@ -159,7 +159,8 @@ public class OAuthTokenManager {
       return f.execute(authData);
     } catch (InvalidTokenException e) {
       if (authData.getRefreshToken() == null || authData.getRefreshToken().isEmpty()) {
-        throw new InvalidTokenException("Refresh token not present", e.getCause());
+        monitor.severe(() -> "Refresh token not present with auth data");
+        throw e;
       }
 
       this.authData = refreshToken();

--- a/extensions/data-transfer/portability-data-transfer-generic/src/test/java/org/datatransferproject/datatransfer/generic/auth/OAuthTokenManagerTest.java
+++ b/extensions/data-transfer/portability-data-transfer-generic/src/test/java/org/datatransferproject/datatransfer/generic/auth/OAuthTokenManagerTest.java
@@ -94,7 +94,8 @@ public class OAuthTokenManagerTest {
                     + "{"
                     + "  \"access_token\": \"newAccessToken\","
                     + "  \"refresh_token\": \"newRefreshToken\","
-                    + "  \"token_type\": \"Bearer\""
+                    + "  \"token_type\": \"Bearer\","
+                    + "  \"some_random_field\": \"some_random_value\""
                     + "}"));
 
     TokensAndUrlAuthData usedAuthData =


### PR DESCRIPTION
don't fail on unknown properties while deserialising RefreshTokenResponse