### PR TITLE
refactor: codehealth rename types to reflect axis of transformation

### DIFF
--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/TransferCompatibilityProvider.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/TransferCompatibilityProvider.java
@@ -41,7 +41,7 @@ public class TransferCompatibilityProvider {
         break;
     }
     if (exporter == null) {
-      return extension.getExporter(jobType); // preserve original exception
+      return extension.getExporter(jobType); // re-execute just for the potential exception
     }
     return exporter;
   }
@@ -64,25 +64,25 @@ public class TransferCompatibilityProvider {
         break;
     }
     if (importer == null) {
-      return extension.getImporter(jobType);
+      return extension.getImporter(jobType); // re-execute just for the potential exception
     }
     return importer;
   }
 
   private Importer<?, ?> getVideosImporter(TransferExtension extension) {
-    Importer media = getImporterOrNull(extension, MEDIA);
-    if (media == null) {
+    Importer mediaImporter = getImporterOrNull(extension, MEDIA);
+    if (mediaImporter == null) {
       return null;
     }
-    return new AnyToAnyImporter<>(media, MediaContainerResource::videoToMedia);
+    return new AnyToAnyImporter<>(mediaImporter, MediaContainerResource::videoToMedia);
   }
 
   private Importer<?, ?> getPhotosImporter(TransferExtension extension) {
-    Importer media = getImporterOrNull(extension, MEDIA);
-    if (media == null) {
+    Importer mediaImporter = getImporterOrNull(extension, MEDIA);
+    if (mediaImporter == null) {
       return null;
     }
-    return new AnyToAnyImporter<>(media, MediaContainerResource::photoToMedia);
+    return new AnyToAnyImporter<>(mediaImporter, MediaContainerResource::photoToMedia);
   }
 
   private Importer<?, ?> getMediaImporter(TransferExtension extension) {


### PR DESCRIPTION
this is entirely a change for code clarity, because if you read (before this patch) the `AnyToAnyImporter#import` generic-params you'll see `To` being passed in as the source of data (what should be a conceptual "From").

The cause of that confusion is that there's multiple different orthogonal transformations happening with/around the `TransferCompatibilityProvider` and its supporting `AnyToAnyImporter` class and DTP generally:

1. DTP moves data from a Exporter producing models to an Importer consuming models
1. we have static functions that convert model A to model B (eg: from Photos model to a Media model via [`MediaContainerResource::photoToMedia`][pToMedia])
   - this is parallel to the `From` and `To` generic params of [`java.util.function.Function<From, To>`][Function].
1. `TransferCompatibilityProvider` converts *an importer* (via `AnyToAnyImporter` and a model-transformer like above) from an importer of one model type to an importer of another model type.

I'm now using the language of "stand-in importer" to indicate which importer was selected as the input (think the `g` in `f(g(x)`) to indicate the key moving piece in that last kind of transformation listed above.

[Function]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/function/Function.html
[pToMedia]: https://github.com/dtinit/data-transfer-project/blob/bca0c7926fb871c7fdd7e206908a87874ec624f2/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaContainerResource.java#L45