### PR TITLE
refactor: include more info in Microsoft stacktrace, when/if available

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftApiResponse.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftApiResponse.java
@@ -277,11 +277,14 @@ public abstract class MicrosoftApiResponse {
 
   /** Returns response body or throws DTP base exception with `causeMessage`. */
   private String checkResponseBody(String causeMessage) throws IOException {
-    return body()
-        .orElseThrow(
-            () ->
-                toIoException(
-                    String.format("HTTP response-body unexpectedly empty: %s", causeMessage)));
+    return body().orElseThrow(() -> {
+      final String causeWithContext = String.format("HTTP response-body unexpectedly empty: %s", causeMessage);
+      if (bodyException().isPresent()) {
+        return toIoException(causeWithContext, bodyException().get());
+      } else {
+        return toIoException(causeWithContext);
+      }
+    });
   }
 
   /** Reads body into memory and checks for needle. */


### PR DESCRIPTION
nit: bodyException() is being populated but never read, which someone… will *really* not appreciate when they try to make sense of a stacktrace some day