### PR TITLE
fix: Add Content-Type and Accept Headers

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/constants/Headers.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/constants/Headers.java
@@ -26,6 +26,7 @@ public enum Headers {
   AUTHORIZATION("Authorization"),
   CORRELATION_ID("X-Apple-Request-UUID"),
   CONTENT_TYPE("Content-Type"),
+  ACCEPT("Accept"),
   OPERATION_GROUP("x-apple-operation-group-name");
 
 

--- a/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/signals/AppleSignalInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/signals/AppleSignalInterface.java
@@ -89,6 +89,8 @@ public class AppleSignalInterface implements AppleBaseInterface {
       con.setRequestMethod("POST");
       con.setRequestProperty(Headers.AUTHORIZATION.getValue(), authData.getAccessToken());
       con.setRequestProperty(Headers.CORRELATION_ID.getValue(), correlationId);
+      con.setRequestProperty(Headers.CONTENT_TYPE.getValue(), "application/json");
+      con.setRequestProperty(Headers.ACCEPT.getValue(), "application/json");
 
       IOUtils.write(requestData, con.getOutputStream());
       responseString = IOUtils.toString(con.getInputStream(), StandardCharsets.ISO_8859_1);


### PR DESCRIPTION
Setting Content-Type and Accept Headers to "application/json" for `AppleSignalInterface`.