### PR TITLE
Add IPV4 Range Filtering for Backblaze B2 API Integration

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientFactory.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientFactory.java
@@ -49,7 +49,13 @@ public class BackblazeDataTransferClientFactory {
                       SIZE_THRESHOLD_FOR_MULTIPART_UPLOAD,
                       PART_SIZE_FOR_MULTIPART_UPLOAD);
       String exportService = JobMetadata.getExportService();
-      backblazeDataTransferClient.init(authData.getToken(), authData.getSecret(), exportService, HttpClientBuilder.create().build());
+      CustomIPv4DnsResolver customDnsResolver = new CustomIPv4DnsResolver();
+      backblazeDataTransferClient.init(
+              authData.getToken(),
+              authData.getSecret(),
+              exportService,
+              HttpClientBuilder.create().setDnsResolver(customDnsResolver).build()
+      );
       backblazeDataTransferClientMap.put(jobId, backblazeDataTransferClient);
     }
     return backblazeDataTransferClientMap.get(jobId);

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/CustomIPv4DnsResolver.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/CustomIPv4DnsResolver.java
@@ -1,0 +1,22 @@
+package org.datatransferproject.datatransfer.backblaze.common;
+
+import org.apache.http.impl.conn.SystemDefaultDnsResolver;
+import org.apache.http.conn.DnsResolver;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+// This class is only required because Backblaze only supports IPV4 on the B2 Native APIs, the S3
+// compatible APIs support IPV6. This can be deleted when all B2 API endpoints support IPV6.
+public class CustomIPv4DnsResolver implements DnsResolver {
+    private final SystemDefaultDnsResolver systemDefaultDnsResolver = new SystemDefaultDnsResolver();
+
+    @Override
+    public InetAddress[] resolve(String host) throws UnknownHostException {
+        // Filter to return only IPv4 addresses
+        return Arrays.stream(systemDefaultDnsResolver.resolve(host))
+                .filter(inetAddress -> inetAddress.getAddress().length == 4)
+                .toArray(InetAddress[]::new);
+    }
+}
+


### PR DESCRIPTION
Currently the B2 Native API only supports IPV4 and Facebook requires IPV6. This change forces an IPV4 DNS resolution when looking up the B2 Authorize endpoint DNS.

This change was tested locally by running the BackblazeIntegrationTest while setting `java.net.preferIPv6Addresses=true`

```
BUILD SUCCESSFUL in 1s
24 actionable tasks: 2 executed, 22 up-to-date
INFO 2025-07-25T12:07:22.601918-05:00 Region extracted from s3ApiUrl: us-east-005
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
DEBUG 2025-07-25T12:07:22.961639-05:00 Uploading 'test-upload-1753463242960' with file size 14 bytes
```

