### PR TITLE
fix(amazon-photos): Add export OAuth scopes

### DIFF
--- a/extensions/auth/portability-auth-amazon/src/main/java/org/datatransferproject/auth/amazon/AmazonOAuthConfig.java
+++ b/extensions/auth/portability-auth-amazon/src/main/java/org/datatransferproject/auth/amazon/AmazonOAuthConfig.java
@@ -46,6 +46,12 @@ public class AmazonOAuthConfig implements OAuth2Config {
 
   @Override
   public Map<DataVertical, Set<String>> getExportScopes() {
-    return ImmutableMap.of();
+    return ImmutableMap.of(
+        PHOTOS, ImmutableSet.of(
+            "amazonphotos::images:read",
+            "amazonphotos::albums:read"),
+        VIDEOS, ImmutableSet.of(
+            "amazonphotos::videos:read",
+            "amazonphotos::albums:read"));
   }
 }

--- a/extensions/auth/portability-auth-amazon/src/test/java/org/datatransferproject/auth/amazon/AmazonOAuthConfigTest.java
+++ b/extensions/auth/portability-auth-amazon/src/test/java/org/datatransferproject/auth/amazon/AmazonOAuthConfigTest.java
@@ -50,7 +50,14 @@ class AmazonOAuthConfigTest {
   }
 
   @Test
-  void exportScopesEmpty() {
-    assertThat(config.getExportScopes()).isEmpty();
+  void exportScopesForPhotos() {
+    assertThat(config.getExportScopes().get(PHOTOS))
+        .containsExactly("amazonphotos::images:read", "amazonphotos::albums:read");
+  }
+
+  @Test
+  void exportScopesForVideos() {
+    assertThat(config.getExportScopes().get(VIDEOS))
+        .containsExactly("amazonphotos::videos:read", "amazonphotos::albums:read");
   }
 }


### PR DESCRIPTION
My earlier PR updated the import scopes to the amazonphotos:: namespace but dropped the export scopes, leaving getExportScopes() empty. That crashes the server on startup (Guice fails provisioning the Amazon export generator with no scopes). This adds them back:
  
  - PHOTOS: amazonphotos::images:read, amazonphotos::albums:read
  - VIDEOS: amazonphotos::videos:read, amazonphotos::albums:read
  
Verified: auth tests pass, server boots and the export consent URL now carries the scopes.