### PR TITLE
feat(offline-demo)!: add exporter and drop Microsoft dependency

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-offline-demo/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-offline-demo/build.gradle
@@ -21,9 +21,6 @@ plugins {
 dependencies {
     compile project(':portability-spi-cloud')
     compile project(':portability-spi-transfer')
-    compile project(':extensions:data-transfer:portability-data-transfer-microsoft')
-
-
 }
 
 configurePublication(project)

--- a/extensions/data-transfer/portability-data-transfer-offline-demo/src/main/java/org/datatransferproject/transfer/offline/DemoOfflineData.java
+++ b/extensions/data-transfer/portability-data-transfer-offline-demo/src/main/java/org/datatransferproject/transfer/offline/DemoOfflineData.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.transfer.offline;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.datatransferproject.types.common.models.DataModel;
+
+/**
+ * Encapsulates offline data for the demo extension. Note the format of the contents is opaque; they
+ * may change without notice.
+ */
+@JsonTypeName("org.dataportability:DemoOfflineData")
+public class DemoOfflineData extends DataModel {
+
+  private final String contents;
+
+  @JsonCreator
+  public DemoOfflineData(@JsonProperty("contents") String contents) {
+    this.contents = contents;
+  }
+
+  public String getContents() {
+    return contents;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-offline-demo/src/main/java/org/datatransferproject/transfer/offline/OfflineDemoExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-offline-demo/src/main/java/org/datatransferproject/transfer/offline/OfflineDemoExporter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.transfer.offline;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.datatransferproject.spi.transfer.provider.ExportResult;
+import org.datatransferproject.spi.transfer.provider.Exporter;
+import org.datatransferproject.types.common.ExportInformation;
+import org.datatransferproject.types.transfer.auth.TokenAuthData;
+
+/**
+ * Simulates exporting offline data. For demo purposes only!
+ *
+ * <p>Returns a fixed payload without contacting any service, so a transfer can be run end to end
+ * without provider credentials. The contents are deterministic so callers may assert on them.
+ */
+public class OfflineDemoExporter implements Exporter<TokenAuthData, DemoOfflineData> {
+
+  /** The payload every export returns. */
+  static final String CONTENTS = "offline-demo data";
+
+  @Override
+  public ExportResult<DemoOfflineData> export(
+      UUID jobId, TokenAuthData authData, Optional<ExportInformation> exportInformation) {
+    // Continuation data is left null: that, rather than the ResultType, is what stops
+    // PortabilityInMemoryDataCopier#copyHelper from recursing.
+    return new ExportResult<>(ExportResult.ResultType.END, new DemoOfflineData(CONTENTS));
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-offline-demo/src/main/java/org/datatransferproject/transfer/offline/OfflineDemoImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-offline-demo/src/main/java/org/datatransferproject/transfer/offline/OfflineDemoImporter.java
@@ -18,23 +18,20 @@ package org.datatransferproject.transfer.offline;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
-import org.datatransferproject.transfer.microsoft.spi.types.MicrosoftOfflineData;
 import org.datatransferproject.types.transfer.auth.TokenAuthData;
 
 import java.util.UUID;
 
 /**
  * Simulates importing offline data. For demo purposes only!
- *
- * <p>Microsoft offline data is used since that is the only form currently supported.
  */
-public class OfflineDemoImporter implements Importer<TokenAuthData, MicrosoftOfflineData> {
+public class OfflineDemoImporter implements Importer<TokenAuthData, DemoOfflineData> {
 
   @Override
   public ImportResult importItem(UUID jobId,
       IdempotentImportExecutor idempotentExecutor,
       TokenAuthData authData,
-      MicrosoftOfflineData data) {
+      DemoOfflineData data) {
     // Print to the console to simulate an import
     System.out.println("Received offline data:\n" + data.getContents());
     return ImportResult.OK;

--- a/extensions/data-transfer/portability-data-transfer-offline-demo/src/main/java/org/datatransferproject/transfer/offline/OfflineDemoTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-offline-demo/src/main/java/org/datatransferproject/transfer/offline/OfflineDemoTransferExtension.java
@@ -1,5 +1,7 @@
 package org.datatransferproject.transfer.offline;
 
+import static org.datatransferproject.types.common.models.DataVertical.OFFLINE_DATA;
+
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
@@ -7,9 +9,10 @@ import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
 
 /**
- * Simulates importing offline data. For demo purposes only!
+ * Simulates transferring offline data. For demo purposes only!
  *
- * <p>Microsoft offline data is used since that is the only form currently supported.
+ * <p>Both sides are credential-free, so this is the one extension pair that can run a complete
+ * transfer without provider API keys.
  */
 public class OfflineDemoTransferExtension implements TransferExtension {
   private static final String SERVICE_ID = "offline-demo";
@@ -21,12 +24,12 @@ public class OfflineDemoTransferExtension implements TransferExtension {
 
   @Override
   public Exporter<?, ?> getExporter(DataVertical transferDataType) {
-    return null;
+    return OFFLINE_DATA.equals(transferDataType) ? new OfflineDemoExporter() : null;
   }
 
   @Override
   public Importer<?, ?> getImporter(DataVertical transferDataType) {
-    return new OfflineDemoImporter();
+    return OFFLINE_DATA.equals(transferDataType) ? new OfflineDemoImporter() : null;
   }
 
   @Override

--- a/extensions/data-transfer/portability-data-transfer-offline-demo/src/test/java/org/datatransferproject/transfer/offline/OfflineDemoTransferTest.java
+++ b/extensions/data-transfer/portability-data-transfer-offline-demo/src/test/java/org/datatransferproject/transfer/offline/OfflineDemoTransferTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.transfer.offline;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.datatransferproject.types.common.models.DataVertical.OFFLINE_DATA;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.provider.ExportResult;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.types.transfer.auth.TokenAuthData;
+import org.junit.jupiter.api.Test;
+
+public class OfflineDemoTransferTest {
+
+  private static final UUID JOB_ID = UUID.randomUUID();
+  private static final TokenAuthData AUTH_DATA = new TokenAuthData("123");
+
+  @Test
+  public void exportsFixedContents() {
+    ExportResult<DemoOfflineData> result =
+        new OfflineDemoExporter().export(JOB_ID, AUTH_DATA, Optional.empty());
+
+    assertThat(result.getType()).isEqualTo(ExportResult.ResultType.END);
+    assertThat(result.getExportedData().getContents()).isEqualTo(OfflineDemoExporter.CONTENTS);
+  }
+
+  @Test
+  public void exportReturnsNoContinuationData() {
+    // PortabilityInMemoryDataCopier#copyHelper recurses on continuation data, not on ResultType,
+    // so null here is what actually ends the copy.
+    ExportResult<DemoOfflineData> result =
+        new OfflineDemoExporter().export(JOB_ID, AUTH_DATA, Optional.empty());
+
+    assertThat(result.getContinuationData()).isNull();
+  }
+
+  @Test
+  public void extensionSuppliesBothSidesOfOfflineData() {
+    OfflineDemoTransferExtension extension = new OfflineDemoTransferExtension();
+
+    assertThat(extension.getExporter(OFFLINE_DATA)).isInstanceOf(OfflineDemoExporter.class);
+    assertThat(extension.getImporter(OFFLINE_DATA)).isInstanceOf(OfflineDemoImporter.class);
+  }
+
+  @Test
+  public void extensionSuppliesNothingForOtherVerticals() {
+    OfflineDemoTransferExtension extension = new OfflineDemoTransferExtension();
+
+    assertThat(extension.getExporter(PHOTOS)).isNull();
+    assertThat(extension.getImporter(PHOTOS)).isNull();
+  }
+
+  @Test
+  public void importsExportedData() {
+    ExportResult<DemoOfflineData> exported =
+        new OfflineDemoExporter().export(JOB_ID, AUTH_DATA, Optional.empty());
+
+    ImportResult result =
+        new OfflineDemoImporter()
+            .importItem(
+                JOB_ID,
+                mock(IdempotentImportExecutor.class),
+                AUTH_DATA,
+                exported.getExportedData());
+
+    assertThat(result.getType()).isEqualTo(ImportResult.ResultType.OK);
+  }
+}


### PR DESCRIPTION
## Summary

`OfflineDemoTransferExtension.getExporter()` has been a literal `return null` since the module was added — the last touch was the mechanical `DataVertical` signature change in `8a0e3e73`. That made the one extension in the repo that bypasses OAuth entirely **import-only**, so it could receive a transfer but never drive one.

This implements it, so `offline-demo` → `offline-demo` is a complete, credential-free transfer path.

It also replaces `MicrosoftOfflineData` with a local `DemoOfflineData`. That type is a 20-line `String` wrapper, and depending on it pulled the **entire Microsoft adapter** — okhttp plus every Graph exporter and importer — into a demo module. `Exporter<A, T extends DataModel>` bounds `T` on `DataModel` rather than `ContainerResource`, so a plain value class is type-legal here.

## Notable decisions / tradeoffs

- **`ResultType.END` with null continuation data.** `PortabilityInMemoryDataCopier#copyHelper` recurses on `continuationData`, not on `ResultType`, so the null continuation is what actually ends the copy. A follow-up PR fixes `ExportResult.END` — the static constant, distinct from the enum used here — which is currently built with `ResultType.CONTINUE`. That fix is independent; nothing in this PR depends on it.

- **No pagination.** A demo exporter faking multiple pages via `IntPaginationToken` would test the copier against a fixture written to satisfy it. Copier recursion is better covered by a real adapter that genuinely paginates.

- **Both `getExporter` and `getImporter` now gate on `OFFLINE_DATA`.** `getImporter` previously returned the importer for *any* vertical. That is unreachable today — `OfflineDemoAuthServiceExtension` advertises only `OFFLINE_DATA`, so no other vertical can produce a job for this service — but `TransferCompatibilityProvider` probes extensions with `getImporterOrNull(extension, MEDIA/PHOTOS/VIDEOS)` and would take the answer if that ever changed.

- **The importer still prints to stdout.** It is the demo's only observable output. Routing it through the `Monitor` that `initialize(context)` already receives and discards is a reasonable follow-up, not part of this diff.

- **The `"OFFLINE-DEMO"` / `"offline-demo"` service-id mismatch is left alone.** `PortabilityAuthServiceProviderRegistry` does an exact-match `MapBinder` lookup while `TransferExtension.supportsService` lowercases both sides, so both spellings work as they are. Changing a published service id has a wider blast radius than the inconsistency warrants.

## ⚠️ Breaking change

`OfflineDemoImporter`'s type parameter changes from `MicrosoftOfflineData` to `DemoOfflineData`. This module is published to Maven Central, so this is a binary-compatibility break for any external consumer — unlikely for a demo importer that prints to stdout, but it warrants a release note.

`MicrosoftOfflineData` and `MicrosoftOfflineDataExporter` themselves are untouched.

## Test plan

- [x] `docker compose run --rm test :extensions:data-transfer:portability-data-transfer-offline-demo:test` — 5 new tests, all passing (the module had none)
- [x] `docker compose run --rm test --no-daemon build` — full repo, catches anything depending on the retyped importer
- [x] `docker compose run --rm test --no-daemon -PofflineData=true :distributions:demo-server:shadowJar` — the only in-repo consumer is `distributions/demo-server/build.gradle:105`, behind that flag, and it references no offline-demo type directly, so a plain `build` would not exercise it

## Stack

This is the first of three PRs building toward a credential-free end-to-end transfer harness:

1. **this PR** — offline-demo becomes a complete export/import pair
2. `distributions/e2e-server` — a slim headless `SingleVMMain` build with no Angular toolchain
3. `e2e/docker-compose.e2e.yml` + a transfer driver
