### PR TITLE
fix(spi-transfer): ExportResult.END carried ResultType.CONTINUE

### DIFF
--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/ExportResult.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/ExportResult.java
@@ -12,7 +12,7 @@ import org.datatransferproject.types.common.models.DataModel;
 public class ExportResult<T extends DataModel> {
 
   public static final ExportResult CONTINUE = new ExportResult(ResultType.CONTINUE);
-  public static final ExportResult END = new ExportResult(ResultType.CONTINUE);
+  public static final ExportResult END = new ExportResult(ResultType.END);
 
   private ResultType type;
   private T exportedData;


### PR DESCRIPTION
## Summary

`ExportResult` exposes two convenience constants. The second one is wrong:

```java
public static final ExportResult CONTINUE = new ExportResult(ResultType.CONTINUE);
public static final ExportResult END = new ExportResult(ResultType.CONTINUE);  // <-- END, built with CONTINUE
```

One character: `END` now carries `ResultType.END`.

## Why it matters, and why it doesn't (yet)

The constant has **no call sites anywhere in the repo** — every exporter constructs `new ExportResult<>(ResultType.END, ...)` directly — so this is latent, not a live bug. Nothing changes for existing code.

It is worth fixing anyway because it is the obvious thing for a new exporter to reach for, and the resulting failure is quiet rather than loud. `PortabilityInMemoryDataCopier#copyHelper` terminates on `continuationData == null`, not on `ResultType`:

```java
ContinuationData continuationData = exportResult.getContinuationData();
if (null != continuationData) { ... recurse ... }
```

So an exporter returning `ExportResult.END` would *not* spin — the constant also carries null `exportedData`, and `copyIteration` skips the import entirely when that is null. The job would run to `COMPLETE` having imported nothing at all. That is a much harder thing to notice than a hang.

I hit this while writing an exporter for the offline-demo module (#1509) and worked around it there by using the enum directly. Splitting the fix out so it lands as a `fix:` in its own right rather than being buried in a `feat:` — this repo squash-merges, so the PR title is what commitizen sees.

## Test plan

- [x] `docker compose run --rm test --no-daemon build` — full repo compiles and tests pass
- [x] `grep -rn "ExportResult.END" --include=*.java .` — confirms the constant has no consumers, so no behaviour changes for existing callers

## Note for downstream consumers

`portability-spi-transfer` is published to Maven Central. Any external caller relying on the current value of `ExportResult.END` would be relying on it reporting `CONTINUE`, which is a bug rather than a contract — but it is a behaviour change for them, so it is worth a line in the release notes.
