### PR TITLE
feat(amazon-photos): harden Photos importer and add shared import helper

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-amazon/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-amazon/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     implementation "com.google.guava:guava:${guavaVersion}"
-    implementation "com.squareup.okhttp3:okhttp:4.9.0"
+    implementation "com.squareup.okhttp3:okhttp:${okHttpVersion}"
 
-    testImplementation "com.squareup.okhttp3:mockwebserver:4.9.0"
+    testImplementation "com.squareup.okhttp3:mockwebserver:${okHttpVersion}"
 }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/AmazonTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/AmazonTransferExtension.java
@@ -22,6 +22,8 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.transfer.amazon.photos.AmazonPhotosImporter;
@@ -34,7 +36,7 @@ public class AmazonTransferExtension implements TransferExtension {
 
   private static final String SERVICE_ID = "Amazon";
 
-  private AmazonPhotosImporter importer;
+  private AmazonPhotosImporter photosImporter;
   private volatile boolean initialized = false;
 
   @Override
@@ -51,8 +53,10 @@ public class AmazonTransferExtension implements TransferExtension {
   @Override
   public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(initialized, "Extension not initialized");
-    Preconditions.checkArgument(transferDataType == DataVertical.PHOTOS);
-    return importer;
+    if (transferDataType == DataVertical.PHOTOS) {
+      return photosImporter;
+    }
+    throw new IllegalArgumentException("Unsupported data type: " + transferDataType);
   }
 
   @Override
@@ -70,9 +74,15 @@ public class AmazonTransferExtension implements TransferExtension {
       return;
     }
 
-    importer = new AmazonPhotosImporter(
+    IdempotentImportExecutor retryingIdempotentExecutor =
+        context.getService(IdempotentImportExecutorExtension.class)
+            .getRetryingIdempotentImportExecutor(context);
+    boolean enableRetrying = context.getSetting("enableRetrying", false);
+
+    photosImporter = new AmazonPhotosImporter(
         monitor, appCredentials.getKey(), appCredentials.getSecret(),
-        context.getService(TemporaryPerJobDataStore.class));
+        context.getService(TemporaryPerJobDataStore.class),
+        retryingIdempotentExecutor, enableRetrying);
 
     initialized = true;
   }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonImportHelper.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonImportHelper.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import org.datatransferproject.spi.cloud.connection.ConnectionProvider;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.types.common.DownloadableItem;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Shared helper for Amazon Photos/Videos importers.
+ * Holds common collaborators and provides reusable import operations.
+ */
+class AmazonImportHelper {
+
+  static final String IMPORTED_SUFFIX = " - Imported from ";
+
+  private final TemporaryPerJobDataStore dataStore;
+  private final ConnectionProvider connectionProvider;
+  private final String clientId;
+  private final String clientSecret;
+  private final Monitor monitor;
+  // Test seam: when set it is always returned in place of a real client.
+  private final AmazonPhotosInterface injectedClient;
+  // Safeguard to avoid sharing a client across jobs: keying by jobId keeps each job's credentials
+  // separate. Bounded, access-order LRU so a long-lived (multi-job) process can't accumulate
+  // clients/tokens without limit; an evicted job just rebuilds its client on its next chunk.
+  // Guarded by getOrCreateClient (synchronized).
+  private static final int MAX_CACHED_CLIENTS = 1000;
+  private final Map<UUID, AmazonPhotosInterface> clientsByJob =
+      new LinkedHashMap<UUID, AmazonPhotosInterface>(16, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<UUID, AmazonPhotosInterface> eldest) {
+          return size() > MAX_CACHED_CLIENTS;
+        }
+      };
+
+  /** Classification/download-only helper (no client provisioning); used where no client is built. */
+  AmazonImportHelper(TemporaryPerJobDataStore dataStore) {
+    this(dataStore, null, null, null, null);
+  }
+
+  /** Production helper that builds a real Amazon client per job from the given app credentials. */
+  AmazonImportHelper(TemporaryPerJobDataStore dataStore, String clientId, String clientSecret,
+                     Monitor monitor) {
+    this(dataStore, clientId, clientSecret, monitor, null);
+  }
+
+  /** Test helper: {@code injectedClient} is always returned by {@link #getOrCreateClient}. */
+  AmazonImportHelper(TemporaryPerJobDataStore dataStore, AmazonPhotosInterface injectedClient) {
+    this(dataStore, null, null, null, injectedClient);
+  }
+
+  private AmazonImportHelper(TemporaryPerJobDataStore dataStore, String clientId,
+                             String clientSecret, Monitor monitor,
+                             AmazonPhotosInterface injectedClient) {
+    this.dataStore = dataStore;
+    this.connectionProvider = new ConnectionProvider(dataStore);
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.monitor = monitor;
+    this.injectedClient = injectedClient;
+  }
+
+  /**
+   * Returns the client for this job, creating and caching it (and resolving endpoints) on first
+   * use. Injected clients are returned as-is; per-job caching keeps each job's credentials
+   * isolated and avoids re-resolving endpoints on every chunk of the same job.
+   */
+  AmazonPhotosInterface getOrCreateClient(UUID jobId, TokensAndUrlAuthData authData)
+      throws IOException {
+    if (injectedClient != null) {
+      return injectedClient;
+    }
+    synchronized (this) {
+      AmazonPhotosInterface existing = clientsByJob.get(jobId);
+      if (existing != null) {
+        return existing;
+      }
+    }
+    // Build and resolve endpoints outside the lock: resolveEndpoints() is a network call, so
+    // holding the shared lock across it would let one job's latency stall getOrCreateClient for
+    // every other concurrent job. Two concurrent first-chunks of the same new job may each build
+    // once; putIfAbsent dedupes storage and the loser is discarded.
+    AmazonPhotosInterface created = createClient(authData);
+    created.resolveEndpoints();
+    synchronized (this) {
+      AmazonPhotosInterface race = clientsByJob.putIfAbsent(jobId, created);
+      return race != null ? race : created;
+    }
+  }
+
+  // Visible-for-testing seam: endpoint resolution otherwise requires a live network call, so
+  // tests override this to inject a fake client.
+  AmazonPhotosInterface createClient(TokensAndUrlAuthData authData) {
+    return new AmazonPhotosClient(
+        AmazonPhotosClient.createDefaultHttpClient(),
+        authData.getAccessToken(), authData.getRefreshToken(), clientId, clientSecret, monitor);
+  }
+
+  /** Creates a new MD5 MessageDigest instance. */
+  MessageDigest newMd5Digest() {
+    return Md5Utils.newDigest();
+  }
+
+  /** Converts a byte array to its lowercase hex string representation. */
+  String toHexString(byte[] bytes) {
+    return Md5Utils.toHexString(bytes);
+  }
+
+  /** Whether the API error indicates the item already exists (duplicate). */
+  boolean isDuplicate(AmazonPhotosApiException e) {
+    return e.isErrorCode(UploadErrorCodes.DUPLICATES_CONFLICT_ERROR);
+  }
+
+  /** Whether the API error indicates the destination storage quota is exceeded. */
+  boolean isStorageQuotaExceeded(AmazonPhotosApiException e) {
+    return e.isErrorCode(UploadErrorCodes.INSUFFICIENT_STORAGE)
+        || e.isErrorCode(UploadErrorCodes.NO_ACTIVE_SUBSCRIPTION_FOUND);
+  }
+
+  /**
+   * Downloads a content item to a temp file, computing MD5 in a single pass.
+   *
+   * <p>The provider-supplied {@code dataId} is untrusted filesystem input, so path separators are
+   * stripped before using it as the temp-file prefix — otherwise {@code Files.createTempFile}
+   * rejects it with an IllegalArgumentException. Only the local prefix is affected; the content
+   * sent to Amazon is unchanged.
+   */
+  File downloadToTempFile(UUID jobId, DownloadableItem item, String dataId,
+                          MessageDigest md5) throws IOException {
+    String prefix = dataId.replaceAll("[/\\\\]", "_");
+    try (InputStream raw = connectionProvider.getInputStreamForItem(jobId, item).getStream();
+         DigestInputStream dis = new DigestInputStream(raw, md5)) {
+      return dataStore.getTempFileFromInputStream(dis, prefix, ".tmp");
+    }
+  }
+
+  /**
+   * Resolves the target album ID from the executor cache.
+   * If albumId is provided but not cached (album creation failed), throws to prevent
+   * silent data loss — photos/videos should not be uploaded without their album.
+   */
+  String resolveTargetAlbumId(String albumId, IdempotentImportExecutor executor)
+      throws Exception {
+    if (albumId == null) {
+      return null;
+    }
+    // This will throw if album creation failed, which marks the item as failed too,
+    // preventing silent loss of album organization.
+    return executor.getCachedValue(albumId);
+  }
+
+  /** Removes temp data from the job store. */
+  void cleanupTempData(UUID jobId, String fetchableUrl) throws IOException {
+    dataStore.removeData(jobId, fetchableUrl);
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosApiException.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosApiException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import java.io.IOException;
+
+/**
+ * Typed exception for non-success Amazon Photos / Upload Service API responses.
+ *
+ * <p>Carries the HTTP status and the service {@code errorCode} (see {@link UploadErrorCodes})
+ * so callers can classify failures on a structured field rather than by substring-matching a
+ * raw response body. Extends {@link IOException} so it flows through the existing DTP
+ * import error handling (e.g. {@code executeAndSwallowIOExceptions}).
+ */
+public class AmazonPhotosApiException extends IOException {
+
+  private final int httpStatus;
+  private final String errorCode;
+
+  /**
+   * @param httpStatus the HTTP status code of the response
+   * @param errorCode the service errorCode from the response body, or {@code null} if absent
+   * @param message a human-readable message (must not embed sensitive raw response detail)
+   */
+  public AmazonPhotosApiException(int httpStatus, String errorCode, String message) {
+    super(message);
+    this.httpStatus = httpStatus;
+    this.errorCode = errorCode;
+  }
+
+  public int getHttpStatus() {
+    return httpStatus;
+  }
+
+  /** The service errorCode, or {@code null} if the response carried none. */
+  public String getErrorCode() {
+    return errorCode;
+  }
+
+  /** Whether this error's {@code errorCode} equals the given code. */
+  public boolean isErrorCode(String code) {
+    return code != null && code.equals(errorCode);
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosClient.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosClient.java
@@ -25,12 +25,20 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode;
 import org.datatransferproject.transfer.amazon.photos.model.CreateNodeRequest;
 import org.datatransferproject.transfer.amazon.photos.model.EndpointResponse;
+import org.datatransferproject.transfer.amazon.photos.model.MultipartUploadInitResponse;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.security.MessageDigest;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * HTTP client for Amazon Photos APIs.
@@ -43,46 +51,100 @@ public class AmazonPhotosClient implements AmazonPhotosInterface {
   private static final String ENDPOINT_URL =
       "https://drive.amazonaws.com/drive/v1/account/endpoint";
   private static final String TOKEN_URL = "https://api.amazon.com/auth/o2/token";
+
+  // HTTP client timeout configuration
+  private static final int CONNECT_TIMEOUT_SECONDS = 30;
+  private static final int READ_TIMEOUT_SECONDS = 60;
+  private static final int WRITE_TIMEOUT_SECONDS = 30;
+
   private static final String RESOURCE_VERSION = "V2";
-  private static final String AUTH_HEADER = "x-amz-access-token";
+  private static final String AUTH_HEADER = "Authorization";
+  private static final String BEARER_PREFIX = "Bearer ";
   private static final String MD5_HEADER = "x-amzn-file-md5";
   private static final String SLASH = "/";
   private static final String NODES_PATH = "nodes";
   private static final String UPLOAD_PATH = "v2/upload/multiform-upload";
+  private static final String MULTIPART_UPLOAD_PATH = "v2/upload/multipart-upload";
+  long multipartThreshold = 4_500_000_000L; // 4.5GB, package-private for testing
   private static final String PARAM_RESOURCE_VERSION = "resourceVersion";
   private static final String PARAM_CONFLICT_RESOLUTION = "conflictResolution";
   private static final String PARAM_NAME = "name";
   private static final String PARAM_KIND = "kind";
   private static final String PARAM_FILE_SIZE = "fileSize";
   private static final String PARAM_PARENT_NODE_ID = "visualCollectionParentNodeId";
-  private static final String PARAM_CONTENT_DATE = "fallbackContentDate";
+  private static final String PARAM_FALLBACK_CONTENT_DATE = "fallbackContentDate";
   private static final String PARAM_FAVORITE = "isFavorite";
   private static final String KIND_FILE = "FILE";
+  private static final String KIND_ALBUM = "VISUAL_COLLECTION";
+  private static final String CONFLICT_RESOLUTION_RENAME = "RENAME";
+  private static final String PARAM_UPLOAD_ID = "uploadId";
+  private static final String PARAM_PART_SIZE = "partSize";
+  private static final String PART_MD5_HEADER = "x-amzn-part-md5";
+  private static final String FORM_PART_METADATA = "metadata";
+  private static final String FORM_PART_FILE = "file";
   private static final MediaType JSON_MEDIA_TYPE = MediaType.parse("application/json");
+  private static final MediaType OCTET_STREAM_TYPE = MediaType.parse("application/octet-stream");
+  // Empty request body for payload-less POSTs (initiate / complete multipart). OkHttp's POST
+  // requires a non-null RequestBody, so a null/absent body is not an option.
+  private static final RequestBody EMPTY_BODY = RequestBody.create(null, new byte[0]);
+
+  private static final String UPLOAD_SUCCEEDED = "UPLOAD_SUCCEEDED";
+  private static final String UPLOAD_COMPLETING = "UPLOAD_COMPLETING";
+
+  // Polling config for waiting on server-side multipart completion.
+  // After complete-upload is called the server stitches parts asynchronously;
+  // larger files (tens of GBs) take significantly longer to process.
+  // Backoff is exponential-with-jitter (1s, 2s, 4s, 8s, 16s, 32s, then capped at 60s),
+  // so it reaches the cap by ~attempt 7. Budget: 85 retries ≈ 80 min total.
+  static final int MAX_POLL_RETRIES = 85;
+  static final double MAX_BACKOFF_SECONDS = 60.0;
+  static final long INITIAL_DELAY_MS = 1500;
+
+  // Package-private and mutable for testing (mirrors multipartThreshold): lets tests exercise the
+  // retry-budget-exhausted paths and skip the initial delay without minutes-long real waits.
+  int pollMaxRetries = MAX_POLL_RETRIES;
+  long initialPollDelayMs = INITIAL_DELAY_MS;
 
   private final OkHttpClient httpClient;
   private final ObjectMapper objectMapper;
   private final String clientId;
   private final String clientSecret;
   private final String refreshToken;
+  private final Monitor monitor;
 
   private volatile String accessToken;
   private volatile String metadataUrl;
   private volatile String uploadServiceUrl;
-  private volatile String contentUrl;
 
   @FunctionalInterface
   interface AuthenticatedCall<T> {
     T execute(String token) throws IOException;
   }
 
+  /**
+   * Creates an OkHttpClient configured with appropriate timeouts for upload operations.
+   */
+  public static OkHttpClient createDefaultHttpClient() {
+    return new OkHttpClient.Builder()
+        .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .writeTimeout(WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .build();
+  }
+
   public AmazonPhotosClient(OkHttpClient httpClient, String accessToken, String refreshToken,
                             String clientId, String clientSecret) {
+    this(httpClient, accessToken, refreshToken, clientId, clientSecret, new Monitor() {});
+  }
+
+  public AmazonPhotosClient(OkHttpClient httpClient, String accessToken, String refreshToken,
+                            String clientId, String clientSecret, Monitor monitor) {
     this.httpClient = httpClient;
     this.accessToken = accessToken;
     this.refreshToken = refreshToken;
     this.clientId = clientId;
     this.clientSecret = clientSecret;
+    this.monitor = monitor;
     this.objectMapper = new ObjectMapper();
   }
 
@@ -95,7 +157,7 @@ public class AmazonPhotosClient implements AmazonPhotosInterface {
     executeWithTokenRefresh(token -> {
       Request request = new Request.Builder()
           .url(ENDPOINT_URL)
-          .addHeader(AUTH_HEADER, token)
+          .addHeader(AUTH_HEADER, BEARER_PREFIX + token)
           .get()
           .build();
 
@@ -103,14 +165,15 @@ public class AmazonPhotosClient implements AmazonPhotosInterface {
         validateResponse(response);
         EndpointResponse endpoints = objectMapper.readValue(
             response.body().string(), EndpointResponse.class);
-        if (endpoints.getMetadataUrl() == null || endpoints.getContentUrl() == null) {
+        if (endpoints.getMetadataUrl() == null || endpoints.getUploadServiceUrl() == null) {
           throw new IOException("Endpoint resolution returned incomplete response");
         }
-        contentUrl = normalizeUrl(endpoints.getContentUrl());
-        uploadServiceUrl = endpoints.getUploadServiceUrl() != null
-            ? normalizeUrl(endpoints.getUploadServiceUrl())
-            : contentUrl;
         metadataUrl = normalizeUrl(endpoints.getMetadataUrl());
+        // We require the upload service URL (not the content URL) from the response, because
+        // multipart upload is only supported on the upload service URL. No fallback.
+        uploadServiceUrl = normalizeUrl(endpoints.getUploadServiceUrl());
+        // The token-refresh wrapper expects the lambda to return a value; this call resolves
+        // endpoints as a side effect and has no result, so we return null.
         return null;
       }
     });
@@ -123,7 +186,7 @@ public class AmazonPhotosClient implements AmazonPhotosInterface {
   public AmazonPhotosNode createAlbum(String name) throws IOException {
     ensureEndpointsResolved();
     return executeWithTokenRefresh(token -> {
-      CreateNodeRequest nodeRequest = new CreateNodeRequest(name, "VISUAL_COLLECTION");
+      CreateNodeRequest nodeRequest = new CreateNodeRequest(name, KIND_ALBUM);
 
       HttpUrl url = HttpUrl.parse(metadataUrl + NODES_PATH).newBuilder()
           .addQueryParameter(PARAM_RESOURCE_VERSION, RESOURCE_VERSION)
@@ -131,9 +194,9 @@ public class AmazonPhotosClient implements AmazonPhotosInterface {
 
       Request request = new Request.Builder()
           .url(url)
-          .addHeader(AUTH_HEADER, token)
+          .addHeader(AUTH_HEADER, BEARER_PREFIX + token)
           .post(RequestBody.create(
-              objectMapper.writeValueAsString(nodeRequest), JSON_MEDIA_TYPE))
+              JSON_MEDIA_TYPE, objectMapper.writeValueAsString(nodeRequest)))
           .build();
 
       try (Response response = httpClient.newCall(request).execute()) {
@@ -144,35 +207,38 @@ public class AmazonPhotosClient implements AmazonPhotosInterface {
   }
 
   /**
-   * Uploads a photo to Amazon Photos.
+   * Uploads a file to Amazon Photos. Uses multipart upload for files > 4.5GB,
+   * otherwise uses the simple multiform upload.
    *
-   * TODO: Add multipart upload support for files > 5GB during video importer integration.
-   *
-   * @throws IOException on API errors including 409 duplicate conflict
+   * @throws IOException if the upload fails, times out during server-side processing,
+   *                     or the thread is interrupted while polling for completion
    */
   @Override
-  public AmazonPhotosNode uploadPhoto(String fileName, File fileContent,
-                                      String md5Hex, long fileSize, String contentDate,
+  public AmazonPhotosNode uploadContent(String fileName, File fileContent,
+                                      String md5Hex, long fileSize, String fallbackContentDate,
                                       boolean isFavorite,
                                       String albumId) throws IOException {
     ensureEndpointsResolved();
+    if (fileSize > multipartThreshold) {
+      return uploadMultipart(fileName, fileContent, md5Hex, fileSize, fallbackContentDate, isFavorite, albumId);
+    }
     return executeWithTokenRefresh(token -> {
-      HttpUrl url = buildUploadUrl(fileName, fileSize, contentDate, isFavorite, albumId);
+      HttpUrl url = buildUploadUrl(fileName, fileSize, fallbackContentDate, isFavorite, albumId);
 
       String metadataJson = objectMapper.writeValueAsString(
-          new CreateNodeRequest(fileName, KIND_FILE));
+          new CreateNodeRequest(fileName, KIND_FILE, CONFLICT_RESOLUTION_RENAME));
 
       RequestBody multipartBody = new okhttp3.MultipartBody.Builder()
           .setType(okhttp3.MultipartBody.FORM)
-          .addFormDataPart("metadata", null,
-              RequestBody.create(metadataJson, JSON_MEDIA_TYPE))
-          .addFormDataPart("file", fileName,
-              RequestBody.create(fileContent, MediaType.parse("application/octet-stream")))
+          .addFormDataPart(FORM_PART_METADATA, null,
+              RequestBody.create(JSON_MEDIA_TYPE, metadataJson))
+          .addFormDataPart(FORM_PART_FILE, fileName,
+              RequestBody.create(OCTET_STREAM_TYPE, fileContent))
           .build();
 
       Request request = new Request.Builder()
           .url(url)
-          .addHeader(AUTH_HEADER, token)
+          .addHeader(AUTH_HEADER, BEARER_PREFIX + token)
           .addHeader(MD5_HEADER, md5Hex)
           .post(multipartBody)
           .build();
@@ -182,6 +248,239 @@ public class AmazonPhotosClient implements AmazonPhotosInterface {
         return objectMapper.readValue(response.body().string(), AmazonPhotosNode.class);
       }
     });
+  }
+
+  private AmazonPhotosNode uploadMultipart(String fileName, File fileContent,
+                                           String md5Hex, long fileSize, String fallbackContentDate,
+                                           boolean isFavorite, String albumId) throws IOException {
+    MultipartUploadInitResponse init = initiateMultipartUpload(
+        fileName, md5Hex, fileSize, fallbackContentDate, isFavorite, albumId);
+    uploadAllParts(fileContent, fileSize, init);
+    completeMultipartUpload(init);
+    pollUntilUploadComplete(init.getNodeId(), init.getUploadId());
+
+    AmazonPhotosNode node = new AmazonPhotosNode();
+    node.setId(init.getNodeId());
+    node.setName(fileName);
+    return node;
+  }
+
+  private MultipartUploadInitResponse initiateMultipartUpload(
+      String fileName, String md5Hex, long fileSize, String fallbackContentDate,
+      boolean isFavorite, String albumId) throws IOException {
+    return executeWithTokenRefresh(token -> {
+      HttpUrl.Builder initUrl = HttpUrl.parse(uploadServiceUrl + MULTIPART_UPLOAD_PATH).newBuilder()
+          .addQueryParameter(PARAM_NAME, fileName)
+          .addQueryParameter(PARAM_KIND, KIND_FILE)
+          .addQueryParameter(PARAM_FILE_SIZE, String.valueOf(fileSize))
+          .addQueryParameter(PARAM_CONFLICT_RESOLUTION, CONFLICT_RESOLUTION_RENAME);
+      if (albumId != null) {
+        initUrl.addQueryParameter(PARAM_PARENT_NODE_ID, albumId);
+      }
+      if (fallbackContentDate != null) {
+        initUrl.addQueryParameter(PARAM_FALLBACK_CONTENT_DATE, fallbackContentDate);
+      }
+      if (isFavorite) {
+        initUrl.addQueryParameter(PARAM_FAVORITE, "true");
+      }
+
+      Request initRequest = new Request.Builder()
+          .url(initUrl.build())
+          .addHeader(AUTH_HEADER, BEARER_PREFIX + token)
+          .addHeader(MD5_HEADER, md5Hex)
+          .post(EMPTY_BODY)
+          .build();
+
+      try (Response initResponse = httpClient.newCall(initRequest).execute()) {
+        validateResponse(initResponse);
+        return objectMapper.readValue(initResponse.body().string(), MultipartUploadInitResponse.class);
+      }
+    });
+  }
+
+  private void uploadAllParts(File fileContent, long fileSize,
+                              MultipartUploadInitResponse init) throws IOException {
+    String nodeId = init.getNodeId();
+    String uploadId = init.getUploadId();
+    long partSize = init.getPartSize();
+    int totalParts = init.getTotalNumberOfParts();
+
+    try (RandomAccessFile raf = new RandomAccessFile(fileContent, "r")) {
+      for (int partNum = 1; partNum <= totalParts; partNum++) {
+        long offset = (partNum - 1) * partSize;
+        long length = Math.min(partSize, fileSize - offset);
+
+        // Pass 1: compute MD5 with small buffer
+        String partMd5 = Md5Utils.computeRegionMd5(raf, offset, length);
+
+        // Pass 2: stream upload from file
+        final int partNumber = partNum;
+        final long partLength = length;
+        executeWithTokenRefresh(token -> {
+          HttpUrl partUrl = HttpUrl.parse(
+              uploadServiceUrl + MULTIPART_UPLOAD_PATH + "/" + nodeId + "/parts/" + partNumber).newBuilder()
+              .addQueryParameter(PARAM_UPLOAD_ID, uploadId)
+              .addQueryParameter(PARAM_PART_SIZE, String.valueOf(partLength))
+              .build();
+
+          RequestBody body = createFileRegionBody(raf, offset, partLength);
+
+          Request partRequest = new Request.Builder()
+              .url(partUrl)
+              .addHeader(AUTH_HEADER, BEARER_PREFIX + token)
+              .addHeader(PART_MD5_HEADER, partMd5)
+              .put(body)
+              .build();
+
+          try (Response partResponse = httpClient.newCall(partRequest).execute()) {
+            validateResponse(partResponse);
+          }
+          return null;
+        });
+      }
+    }
+  }
+
+  private void completeMultipartUpload(MultipartUploadInitResponse init) throws IOException {
+    executeWithTokenRefresh(token -> {
+      HttpUrl completeUrl = HttpUrl.parse(
+          uploadServiceUrl + MULTIPART_UPLOAD_PATH + "/" + init.getNodeId() + "/complete").newBuilder()
+          .addQueryParameter(PARAM_UPLOAD_ID, init.getUploadId())
+          .build();
+
+      Request completeRequest = new Request.Builder()
+          .url(completeUrl)
+          .addHeader(AUTH_HEADER, BEARER_PREFIX + token)
+          .post(EMPTY_BODY)
+          .build();
+
+      try (Response completeResponse = httpClient.newCall(completeRequest).execute()) {
+        validateResponse(completeResponse);
+      }
+      return null;
+    });
+  }
+
+  private void pollUntilUploadComplete(String nodeId, String uploadId) throws IOException {
+    long startMs = System.currentTimeMillis();
+
+    // Initial delay before first poll to let server begin processing
+    RetryUtils.sleep(initialPollDelayMs);
+
+    for (int attempt = 1; attempt <= pollMaxRetries; attempt++) {
+      final int currentAttempt = attempt;
+
+      JsonNode progress;
+      String status;
+      try {
+        progress = getMultipartUploadProgress(nodeId, uploadId);
+        JsonNode statusNode = progress.path("status");
+        if (!statusNode.isTextual()) {
+          // A 2xx response with a missing/non-textual "status" is malformed; treat it as a
+          // transient/retryable IOException rather than letting .asText() NPE out of the loop.
+          throw new IOException(String.format(
+              "Multipart progress response missing 'status' field for node: %s", nodeId));
+        }
+        status = statusNode.asText();
+      } catch (IOException e) {
+        // Fail fast on a definitive client error (4xx other than 429) -- the progress endpoint
+        // will not recover (e.g. 404 upload-not-found, 403), so polling it through the whole
+        // budget is pointless. Transient server errors (5xx / 429), network blips, and
+        // malformed/unparseable bodies fall through and are retried until the budget is exhausted.
+        if (e instanceof AmazonPhotosApiException) {
+          int httpStatus = ((AmazonPhotosApiException) e).getHttpStatus();
+          if (httpStatus >= 400 && httpStatus < 500 && httpStatus != 429) {
+            throw e;
+          }
+        }
+        monitor.info(() -> String.format(
+            "[MultipartPoll] node=%s attempt=%d/%d progress check errored, will retry: %s",
+            nodeId, currentAttempt, pollMaxRetries, e.getMessage()));
+        if (attempt < pollMaxRetries) {
+          RetryUtils.sleep(RetryUtils.computeBackoffMillis(attempt, MAX_BACKOFF_SECONDS));
+          continue;
+        }
+        throw new IOException(String.format(
+            "Multipart upload progress check did not succeed within %d retries for node: %s",
+            pollMaxRetries, nodeId), e);
+      }
+
+      long elapsedMs = System.currentTimeMillis() - startMs;
+
+      monitor.info(() -> String.format(
+          "[MultipartPoll] node=%s attempt=%d/%d status=%s elapsed=%dms",
+          nodeId, currentAttempt, pollMaxRetries, status, elapsedMs));
+
+      if (UPLOAD_SUCCEEDED.equals(status)) {
+        monitor.info(() -> String.format(
+            "[MultipartPoll] node=%s completed: retries=%d durationMs=%d",
+            nodeId, currentAttempt, elapsedMs));
+        return;
+      } else if (UPLOAD_COMPLETING.equals(status)) {
+        if (attempt < pollMaxRetries) {
+          long backoffMs = RetryUtils.computeBackoffMillis(attempt, MAX_BACKOFF_SECONDS);
+          RetryUtils.sleep(backoffMs);
+        }
+      } else {
+        throw new IOException(String.format(
+            "Multipart upload failed for node: %s (status=%s, details=%s)",
+            nodeId, status, progress));
+      }
+    }
+
+    long totalMs = System.currentTimeMillis() - startMs;
+    throw new IOException(String.format(
+        "Multipart upload did not complete within %d retries (%dms) for node: %s",
+        pollMaxRetries, totalMs, nodeId));
+  }
+
+  /**
+   * Returns the current status and metadata of a multipart upload.
+   */
+  JsonNode getMultipartUploadProgress(String nodeId, String uploadId) throws IOException {
+    return executeWithTokenRefresh(token -> {
+      HttpUrl progressUrl = HttpUrl.parse(
+          uploadServiceUrl + MULTIPART_UPLOAD_PATH + "/" + nodeId).newBuilder()
+          .addQueryParameter(PARAM_UPLOAD_ID, uploadId)
+          .build();
+
+      Request request = new Request.Builder()
+          .url(progressUrl)
+          .addHeader(AUTH_HEADER, BEARER_PREFIX + token)
+          .get()
+          .build();
+
+      try (Response response = httpClient.newCall(request).execute()) {
+        validateResponse(response);
+        return objectMapper.readTree(response.body().string());
+      }
+    });
+  }
+
+  /**
+   * Creates a streaming RequestBody that reads a file region directly into the HTTP request,
+   * avoiding loading the entire part into heap memory.
+   */
+  private static RequestBody createFileRegionBody(RandomAccessFile raf, long offset, long length) {
+    return new RequestBody() {
+      @Override public MediaType contentType() {
+        return OCTET_STREAM_TYPE;
+      }
+      @Override public long contentLength() {
+        return length;
+      }
+      @Override public void writeTo(okio.BufferedSink sink) throws IOException {
+        raf.seek(offset);
+        byte[] buf = new byte[8192];
+        long remaining = length;
+        while (remaining > 0) {
+          int toRead = (int) Math.min(buf.length, remaining);
+          raf.readFully(buf, 0, toRead);
+          sink.write(buf, 0, toRead);
+          remaining -= toRead;
+        }
+      }
+    };
   }
 
   private <T> T executeWithTokenRefresh(AuthenticatedCall<T> call) throws IOException {
@@ -217,23 +516,50 @@ public class AmazonPhotosClient implements AmazonPhotosInterface {
     }
     if (!response.isSuccessful()) {
       String errorBody = response.body() != null ? response.body().string() : "";
-      throw new IOException("API error " + response.code() + ": " + errorBody);
+      String errorCode = extractJsonField(errorBody, "errorCode");
+      String errorMessage = extractJsonField(errorBody, "message");
+
+      String detail = Stream.of(
+              errorCode != null ? "errorCode=" + errorCode : null,
+              errorMessage != null ? "message=" + errorMessage : null)
+          .filter(Objects::nonNull)
+          .collect(Collectors.joining(", "));
+      String message = "Amazon Photos API error: HTTP " + response.code()
+          + (detail.isEmpty() ? "" : " (" + detail + ")");
+      throw new AmazonPhotosApiException(response.code(), errorCode, message);
     }
   }
 
-  private HttpUrl buildUploadUrl(String fileName, long fileSize, String contentDate,
+  /**
+   * Extracts a top-level textual field from a JSON error body, or {@code null} if the body is
+   * empty, not JSON, or the field is missing/non-textual. Only specific, reviewed fields
+   * ({@code errorCode}, {@code message}) are surfaced -- the raw body is never embedded -- so
+   * error logs stay diagnosable (code + message together) without leaking excess response detail.
+   */
+  private String extractJsonField(String errorBody, String field) {
+    if (errorBody == null || errorBody.isEmpty()) {
+      return null;
+    }
+    try {
+      JsonNode node = objectMapper.readTree(errorBody).get(field);
+      return (node != null && node.isTextual()) ? node.asText() : null;
+    } catch (IOException e) {
+      return null;
+    }
+  }
+
+  private HttpUrl buildUploadUrl(String fileName, long fileSize, String fallbackContentDate,
                                  boolean isFavorite, String albumId) {
     HttpUrl.Builder builder = HttpUrl.parse(uploadServiceUrl + UPLOAD_PATH).newBuilder()
         .addQueryParameter(PARAM_NAME, fileName)
         .addQueryParameter(PARAM_KIND, KIND_FILE)
-        .addQueryParameter(PARAM_FILE_SIZE, String.valueOf(fileSize))
-        .addQueryParameter(PARAM_CONFLICT_RESOLUTION, "RENAME");
+        .addQueryParameter(PARAM_FILE_SIZE, String.valueOf(fileSize));
 
     if (albumId != null) {
       builder.addQueryParameter(PARAM_PARENT_NODE_ID, albumId);
     }
-    if (contentDate != null) {
-      builder.addQueryParameter(PARAM_CONTENT_DATE, contentDate);
+    if (fallbackContentDate != null) {
+      builder.addQueryParameter(PARAM_FALLBACK_CONTENT_DATE, fallbackContentDate);
     }
     if (isFavorite) {
       builder.addQueryParameter(PARAM_FAVORITE, "true");
@@ -246,9 +572,9 @@ public class AmazonPhotosClient implements AmazonPhotosInterface {
   }
 
   private void ensureEndpointsResolved() throws IOException {
-    if (metadataUrl == null) {
+    if (metadataUrl == null || uploadServiceUrl == null) {
       synchronized (this) {
-        if (metadataUrl == null) {
+        if (metadataUrl == null || uploadServiceUrl == null) {
           resolveEndpoints();
         }
       }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosImporter.java
@@ -17,7 +17,6 @@
 package org.datatransferproject.transfer.amazon.photos;
 
 import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.cloud.connection.ConnectionProvider;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
@@ -33,10 +32,7 @@ import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.security.DigestInputStream;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -51,148 +47,109 @@ import java.util.UUID;
 public class AmazonPhotosImporter
     implements Importer<TokensAndUrlAuthData, PhotosContainerResource> {
 
-  private static final String IMPORTED_SUFFIX = " - Imported from ";
-
   private final Monitor monitor;
-  private final String clientId;
-  private final String clientSecret;
-  private final TemporaryPerJobDataStore dataStore;
-  private final ConnectionProvider connectionProvider;
+  private final AmazonImportHelper importHelper;
   private final AmazonPhotosTransmogrificationConfig transmogrificationConfig =
       new AmazonPhotosTransmogrificationConfig();
-
-  private AmazonPhotosInterface client;
+  private final IdempotentImportExecutor retryingIdempotentExecutor;
+  private final boolean enableRetrying;
 
   public AmazonPhotosImporter(Monitor monitor, String clientId, String clientSecret,
-                              TemporaryPerJobDataStore dataStore) {
+                              TemporaryPerJobDataStore dataStore,
+                              IdempotentImportExecutor retryingIdempotentExecutor,
+                              boolean enableRetrying) {
     this.monitor = monitor;
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
-    this.dataStore = dataStore;
-    this.connectionProvider = new ConnectionProvider(dataStore);
+    this.importHelper = new AmazonImportHelper(dataStore, clientId, clientSecret, monitor);
+    this.retryingIdempotentExecutor = retryingIdempotentExecutor;
+    this.enableRetrying = enableRetrying;
   }
 
   AmazonPhotosImporter(Monitor monitor, TemporaryPerJobDataStore dataStore,
                        AmazonPhotosInterface client) {
+    this(monitor, dataStore, client, null, false);
+  }
+
+  AmazonPhotosImporter(Monitor monitor, TemporaryPerJobDataStore dataStore,
+                       AmazonPhotosInterface client,
+                       IdempotentImportExecutor retryingIdempotentExecutor,
+                       boolean enableRetrying) {
     this.monitor = monitor;
-    this.clientId = null;
-    this.clientSecret = null;
-    this.dataStore = dataStore;
-    this.connectionProvider = new ConnectionProvider(dataStore);
-    this.client = client;
+    this.importHelper = new AmazonImportHelper(dataStore, client);
+    this.retryingIdempotentExecutor = retryingIdempotentExecutor;
+    this.enableRetrying = enableRetrying;
   }
 
   @Override
-  public ImportResult importItem(UUID jobId, IdempotentImportExecutor executor,
+  public ImportResult importItem(UUID jobId, IdempotentImportExecutor idempotentImportExecutor,
                                  TokensAndUrlAuthData authData,
                                  PhotosContainerResource data) throws Exception {
-    initializeClient(authData);
+    AmazonPhotosInterface client = importHelper.getOrCreateClient(jobId, authData);
     data.transmogrify(transmogrificationConfig);
+
+    // Prefer the platform's retrying executor when enabled so transient failures are retried
+    // (per the host-configured RetryStrategyLibrary) before being recorded and skipped.
+    IdempotentImportExecutor executor =
+        (retryingIdempotentExecutor != null && enableRetrying)
+            ? retryingIdempotentExecutor
+            : idempotentImportExecutor;
 
     for (PhotoAlbum album : data.getAlbums()) {
       executor.executeAndSwallowIOExceptions(
-          album.getId(), album.getName(), () -> createAlbum(album));
+          album.getId(), album.getName(), () -> createAlbum(client, album));
     }
 
     for (PhotoModel photo : data.getPhotos()) {
       executor.executeAndSwallowIOExceptions(
           photo.getIdempotentId(), photo.getTitle(),
-          () -> uploadPhoto(jobId, photo, executor));
+          () -> uploadPhoto(client, jobId, photo, executor));
     }
 
     return ImportResult.OK;
   }
 
-  private String createAlbum(PhotoAlbum album) throws IOException {
-    String albumName = album.getName() + IMPORTED_SUFFIX + JobMetadata.getExportService();
+  private String createAlbum(AmazonPhotosInterface client, PhotoAlbum album) throws IOException {
+    String albumName = album.getName() + AmazonImportHelper.IMPORTED_SUFFIX + JobMetadata.getExportService();
     AmazonPhotosNode node = client.createAlbum(albumName);
-    monitor.info(() -> "Created album: " + album.getName() + " -> " + node.getId());
+    monitor.info(() -> "Created album " + album.getId() + " -> " + node.getId());
     return node.getId();
   }
 
-  private String uploadPhoto(UUID jobId, PhotoModel photo,
+  private String uploadPhoto(AmazonPhotosInterface client, UUID jobId, PhotoModel photo,
                              IdempotentImportExecutor executor) throws Exception {
-    String targetAlbumId = resolveTargetAlbumId(photo, executor);
-    MessageDigest md5 = newMd5Digest();
-    File tempFile = downloadToTempFile(jobId, photo, md5);
+    String targetAlbumId = importHelper.resolveTargetAlbumId(photo.getAlbumId(), executor);
+    MessageDigest md5 = importHelper.newMd5Digest();
+    File tempFile = importHelper.downloadToTempFile(jobId, photo, photo.getDataId(), md5);
 
     try {
-      String md5Hex = toHexString(md5.digest());
+      String md5Hex = importHelper.toHexString(md5.digest());
       long fileSize = tempFile.length();
-      String contentDate = Optional.ofNullable(photo.getUploadedTime())
+      String fallbackContentDate = Optional.ofNullable(photo.getUploadedTime())
           .map(d -> d.toInstant().toString())
           .orElse(Instant.now().toString());
       boolean isFavorite = Optional.ofNullable(photo.getFavoriteInfo())
           .map(FavoriteInfo::getFavorited)
           .orElse(false);
 
-      AmazonPhotosNode uploadedNode = client.uploadPhoto(
+      AmazonPhotosNode uploadedNode = client.uploadContent(
           photo.getTitle(), tempFile, md5Hex,
-          fileSize, contentDate, isFavorite, targetAlbumId);
+          fileSize, fallbackContentDate, isFavorite, targetAlbumId);
 
       return uploadedNode.getId();
 
-    } catch (IOException e) {
-      if (e.getMessage() != null && e.getMessage().contains("DuplicatesConflictError")) {
-        monitor.info(() -> "Duplicate photo skipped: " + photo.getTitle());
+    } catch (AmazonPhotosApiException e) {
+      if (importHelper.isDuplicate(e)) {
+        monitor.info(() -> "Duplicate photo skipped: " + photo.getDataId());
         return photo.getDataId();
       }
-      if (isStorageQuotaExceeded(e)) {
+      if (importHelper.isStorageQuotaExceeded(e)) {
         throw new DestinationMemoryFullException("Amazon Photos storage full", e);
       }
       throw e;
     } finally {
       tempFile.delete();
       if (photo.isInTempStore()) {
-        dataStore.removeData(jobId, photo.getFetchableUrl());
+        importHelper.cleanupTempData(jobId, photo.getFetchableUrl());
       }
     }
-  }
-
-  private String resolveTargetAlbumId(PhotoModel photo, IdempotentImportExecutor executor)
-      throws Exception {
-    if (photo.getAlbumId() != null && executor.isKeyCached(photo.getAlbumId())) {
-      return executor.getCachedValue(photo.getAlbumId());
-    }
-    return null;
-  }
-
-  private void initializeClient(TokensAndUrlAuthData authData) throws IOException {
-    if (client == null) {
-      client = new AmazonPhotosClient(
-          new okhttp3.OkHttpClient.Builder().build(),
-          authData.getAccessToken(), authData.getRefreshToken(), clientId, clientSecret);
-      client.resolveEndpoints();
-    }
-  }
-
-  private File downloadToTempFile(UUID jobId, PhotoModel photo, MessageDigest md5)
-      throws IOException {
-    String prefix = photo.getDataId().replaceAll("[/\\\\]", "_");
-    try (InputStream raw = connectionProvider.getInputStreamForItem(jobId, photo).getStream();
-         DigestInputStream dis = new DigestInputStream(raw, md5)) {
-      return dataStore.getTempFileFromInputStream(dis, prefix, ".tmp");
-    }
-  }
-
-  private static MessageDigest newMd5Digest() {
-    try {
-      return MessageDigest.getInstance("MD5");
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("MD5 algorithm not available", e);
-    }
-  }
-
-  private static String toHexString(byte[] bytes) {
-    StringBuilder hex = new StringBuilder(bytes.length * 2);
-    for (byte b : bytes) {
-      hex.append(String.format("%02x", b));
-    }
-    return hex.toString();
-  }
-
-  private static boolean isStorageQuotaExceeded(IOException e) {
-    String message = e.getMessage();
-    return message != null && message.contains("InsufficientStorage");
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosInterface.java
@@ -41,20 +41,23 @@ public interface AmazonPhotosInterface {
   AmazonPhotosNode createAlbum(String name) throws IOException;
 
   /**
-   * Uploads a photo to Amazon Photos using the multiform upload API.
-   * If albumId is provided, the photo is linked to the album atomically.
+   * Uploads content (photo or video) to Amazon Photos.
+   * Uses multipart upload for files exceeding the threshold, otherwise simple multiform upload.
+   * If albumId is provided, the content is linked to the album atomically.
    *
-   * @param fileName the photo filename
-   * @param fileContent raw file bytes
+   * @param fileName the content filename
+   * @param fileContent the file to upload
    * @param md5Hex hex-encoded MD5 of the file content
    * @param fileSize size in bytes
-   * @param contentDate fallback content date (ISO 8601) if EXIF is unavailable
-   * @param isFavorite whether to mark the photo as favorite
-   * @param albumId album to link the photo to, or null for no album
+   * @param fallbackContentDate fallback content date (ISO 8601) if EXIF is unavailable
+   * @param isFavorite whether to mark as favorite
+   * @param albumId album to link the content to, or null for no album
    * @return the created node with id and name
    * @throws IOException on API errors (4xx/5xx)
    */
-  AmazonPhotosNode uploadPhoto(String fileName, File fileContent,
-                               String md5Hex, long fileSize, String contentDate,
-                               boolean isFavorite, String albumId) throws IOException;
+  AmazonPhotosNode uploadContent(String fileName, File fileContent,
+                                 String md5Hex, long fileSize, String fallbackContentDate,
+                                 boolean isFavorite, String albumId) throws IOException;
+
+
 }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosTransmogrificationConfig.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosTransmogrificationConfig.java
@@ -18,7 +18,12 @@ package org.datatransferproject.transfer.amazon.photos;
 
 import org.datatransferproject.types.common.models.TransmogrificationConfig;
 
-/** Transmogrification config for Amazon Photos imports. */
+/**
+ * Defines the Amazon Photos-specific limits that the DTP transmogrification step applies to
+ * incoming data before import — here, the maximum album-name and photo-title lengths. DTP invokes
+ * this config (via {@code data.transmogrify(...)}) to normalize/trim source data so it conforms to
+ * Amazon Photos constraints.
+ */
 public class AmazonPhotosTransmogrificationConfig extends TransmogrificationConfig {
 
   private static final int MAX_ALBUM_NAME_LENGTH = 200;

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/Md5Utils.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/Md5Utils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * MD5 utilities for Amazon Photos upload APIs.
+ * MD5 is used here as an API-mandated content checksum, not for security.
+ */
+final class Md5Utils {
+
+  private Md5Utils() {}
+
+  /** Creates a new MD5 MessageDigest instance. */
+  static MessageDigest newDigest() {
+    try {
+      return MessageDigest.getInstance("MD5");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("MD5 algorithm not available", e);
+    }
+  }
+
+  /** Converts a byte array to its lowercase hex string representation. */
+  static String toHexString(byte[] bytes) {
+    StringBuilder hex = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      hex.append(String.format("%02x", b));
+    }
+    return hex.toString();
+  }
+
+  /** Computes MD5 hex of a file region using a small buffer (no large heap allocation). */
+  static String computeRegionMd5(RandomAccessFile raf, long offset, long length)
+      throws IOException {
+    MessageDigest md = newDigest();
+    raf.seek(offset);
+    byte[] buf = new byte[8192];
+    long remaining = length;
+    while (remaining > 0) {
+      int toRead = (int) Math.min(buf.length, remaining);
+      raf.readFully(buf, 0, toRead);
+      md.update(buf, 0, toRead);
+      remaining -= toRead;
+    }
+    return toHexString(md.digest());
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/RetryUtils.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/RetryUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Retry utilities for Amazon Photos multipart upload polling.
+ */
+final class RetryUtils {
+
+  private RetryUtils() {}
+
+  /**
+   * Computes an exponential backoff with jitter, in millis.
+   * Base grows as 2^(attempt-1) seconds (1, 2, 4, 8, 16, 32, ...), capped at {@code maxSeconds},
+   * then scaled by a random factor in [1.0, 1.3) to spread out retries and avoid a thundering herd.
+   */
+  static long computeBackoffMillis(int attempt, double maxSeconds) {
+    double base = Math.min(Math.pow(2, attempt - 1), maxSeconds);
+    double jitter = 1.0 + ThreadLocalRandom.current().nextDouble() * 0.3;
+    return Math.round(base * jitter * 1000);
+  }
+
+  /**
+   * Sleeps for the given duration. Throws IOException if the thread is interrupted
+   * (e.g. due to job cancellation via DTP's worker thread interrupt mechanism).
+   */
+  static void sleep(long millis) throws IOException {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Polling interrupted", e);
+    }
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/UploadErrorCodes.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/UploadErrorCodes.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+/**
+ * Client-facing Upload Service error codes we classify on. These mirror the external names in
+ * the Upload Service's {@code UploadErrorCode} enum and are part of the API contract (changing
+ * them would break backward compatibility), so matching on them is stable.
+ */
+final class UploadErrorCodes {
+
+  private UploadErrorCodes() {}
+
+  /** An identical item already exists (returned on HTTP 409). */
+  static final String DUPLICATES_CONFLICT_ERROR = "DuplicatesConflictError";
+
+  /** Destination storage quota exceeded (returned on HTTP 403, distinct from other 403s). */
+  static final String INSUFFICIENT_STORAGE = "InsufficientStorage";
+
+  /**
+   * No active storage subscription for the account (returned on HTTP 403). Treated as a
+   * storage-quota condition because the upload cannot proceed without sufficient allowance.
+   */
+  static final String NO_ACTIVE_SUBSCRIPTION_FOUND = "NoActiveSubscriptionFound";
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/model/AmazonPhotosNode.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/model/AmazonPhotosNode.java
@@ -30,5 +30,7 @@ public class AmazonPhotosNode {
   private String name;
 
   public String getId() { return id; }
+  public void setId(String id) { this.id = id; }
   public String getName() { return name; }
+  public void setName(String name) { this.name = name; }
 }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/model/MultipartUploadInitResponse.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/model/MultipartUploadInitResponse.java
@@ -16,29 +16,20 @@
 
 package org.datatransferproject.transfer.amazon.photos.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** Request body for node creation API (POST /nodes) and upload metadata. */
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public class CreateNodeRequest {
+/** Response from the multipart upload initiate API. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MultipartUploadInitResponse {
 
-  @JsonProperty("name")
-  private final String name;
+  @JsonProperty("nodeId") private String nodeId;
+  @JsonProperty("uploadId") private String uploadId;
+  @JsonProperty("partSize") private long partSize;
+  @JsonProperty("totalNumberOfParts") private int totalNumberOfParts;
 
-  @JsonProperty("kind")
-  private final String kind;
-
-  @JsonProperty("conflictResolution")
-  private final String conflictResolution;
-
-  public CreateNodeRequest(String name, String kind) {
-    this(name, kind, null);
-  }
-
-  public CreateNodeRequest(String name, String kind, String conflictResolution) {
-    this.name = name;
-    this.kind = kind;
-    this.conflictResolution = conflictResolution;
-  }
+  public String getNodeId() { return nodeId; }
+  public String getUploadId() { return uploadId; }
+  public long getPartSize() { return partSize; }
+  public int getTotalNumberOfParts() { return totalNumberOfParts; }
 }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonImportHelperTest.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonImportHelperTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+/** Unit tests for {@link AmazonImportHelper} error classification and client provisioning. */
+class AmazonImportHelperTest {
+
+  private static final TokensAndUrlAuthData AUTH_DATA =
+      new TokensAndUrlAuthData("access", "refresh", "http://token-url");
+
+  private AmazonImportHelper helper;
+
+  @BeforeEach
+  void setUp() {
+    helper = new AmazonImportHelper(mock(TemporaryPerJobDataStore.class));
+  }
+
+  private static AmazonPhotosApiException error(int status, String errorCode) {
+    return new AmazonPhotosApiException(status, errorCode, "message");
+  }
+
+  @Test
+  void isStorageQuotaExceeded_insufficientStorage_isTrue() {
+    assertTrue(helper.isStorageQuotaExceeded(error(403, UploadErrorCodes.INSUFFICIENT_STORAGE)));
+  }
+
+  @Test
+  void isStorageQuotaExceeded_noActiveSubscriptionFound_isTrue() {
+    assertTrue(helper.isStorageQuotaExceeded(
+        error(403, UploadErrorCodes.NO_ACTIVE_SUBSCRIPTION_FOUND)));
+  }
+
+  @Test
+  void isStorageQuotaExceeded_otherErrorCode_isFalse() {
+    assertFalse(helper.isStorageQuotaExceeded(error(403, "ForbiddenAccess")));
+  }
+
+  @Test
+  void isStorageQuotaExceeded_nullErrorCode_isFalse() {
+    assertFalse(helper.isStorageQuotaExceeded(error(500, null)));
+  }
+
+  @Test
+  void isDuplicate_duplicatesConflictError_isTrue() {
+    assertTrue(helper.isDuplicate(error(409, UploadErrorCodes.DUPLICATES_CONFLICT_ERROR)));
+  }
+
+  @Test
+  void isDuplicate_otherErrorCode_isFalse() {
+    assertFalse(helper.isDuplicate(error(409, UploadErrorCodes.INSUFFICIENT_STORAGE)));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Client provisioning: per-job isolation + injected/test seam.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void getOrCreateClient_returnsInjectedClientWithoutBuilding() throws Exception {
+    AmazonPhotosInterface injected = mock(AmazonPhotosInterface.class);
+    AmazonImportHelper h =
+        new AmazonImportHelper(mock(TemporaryPerJobDataStore.class), injected);
+
+    assertEquals(injected, h.getOrCreateClient(UUID.randomUUID(), AUTH_DATA));
+    // Injected clients are supplied ready-to-use; the helper must not resolve endpoints itself.
+    verify(injected, never()).resolveEndpoints();
+  }
+
+  @Test
+  void getOrCreateClient_isolatesClientPerJobAndReusesWithinJob() throws Exception {
+    AmazonImportHelper h = spy(new AmazonImportHelper(
+        mock(TemporaryPerJobDataStore.class), "client-id", "client-secret", mock(Monitor.class)));
+    AmazonPhotosInterface built = mock(AmazonPhotosInterface.class);
+    doReturn(built).when(h).createClient(eq(AUTH_DATA));
+    UUID jobA = UUID.randomUUID();
+    UUID jobB = UUID.randomUUID();
+
+    // Same job: the client is built once and reused across chunks (endpoints resolved once).
+    assertEquals(built, h.getOrCreateClient(jobA, AUTH_DATA));
+    assertEquals(built, h.getOrCreateClient(jobA, AUTH_DATA));
+    verify(h, times(1)).createClient(eq(AUTH_DATA));
+    verify(built, times(1)).resolveEndpoints();
+
+    // Different job: a fresh client is built, so one job's credentials never serve another.
+    h.getOrCreateClient(jobB, AUTH_DATA);
+    verify(h, times(2)).createClient(eq(AUTH_DATA));
+  }
+
+  @Test
+  void createClient_buildsClientWithoutNetwork() {
+    AmazonImportHelper h = new AmazonImportHelper(
+        mock(TemporaryPerJobDataStore.class), "client-id", "client-secret", mock(Monitor.class));
+    // Constructing the client does no network I/O (endpoint resolution is a separate call).
+    assertNotNull(h.createClient(AUTH_DATA));
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosClientTest.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosClientTest.java
@@ -30,16 +30,21 @@ import org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class AmazonPhotosClientTest {
 
   private MockWebServer server;
   private AmazonPhotosClient client;
   private File tempFile;
+
+  @TempDir
+  Path tempDir;
 
   private static final String ACCESS_TOKEN = "test-access-token";
   private static final String REFRESH_TOKEN = "test-refresh-token";
@@ -70,8 +75,7 @@ public class AmazonPhotosClientTest {
     enqueueEndpointResponse();
     client.resolveEndpoints();
 
-    tempFile = File.createTempFile("test", ".jpg");
-    tempFile.deleteOnExit();
+    tempFile = tempDir.resolve("test.jpg").toFile();
     Files.write(tempFile.toPath(), new byte[]{1, 2, 3});
   }
 
@@ -84,7 +88,7 @@ public class AmazonPhotosClientTest {
   void resolveEndpoints_sendsAuthHeader() throws Exception {
     RecordedRequest request = server.takeRequest();
     assertEquals("GET", request.getMethod());
-    assertEquals(ACCESS_TOKEN, request.getHeader("x-amz-access-token"));
+    assertEquals("Bearer " + ACCESS_TOKEN, request.getHeader("Authorization"));
     assertTrue(request.getPath().contains("/drive/v1/account/endpoint"));
   }
 
@@ -129,13 +133,13 @@ public class AmazonPhotosClientTest {
   }
 
   @Test
-  void uploadPhoto_sendsContentAndHeaders() throws Exception {
+  void uploadContent_sendsContentAndHeaders() throws Exception {
     server.takeRequest();
 
     server.enqueue(new MockResponse()
         .setBody("{\"id\":\"photo1\",\"name\":\"test.jpg\",\"kind\":\"FILE\"}"));
 
-    AmazonPhotosNode node = client.uploadPhoto(
+    AmazonPhotosNode node = client.uploadContent(
         "test.jpg", tempFile, "md5hex", tempFile.length(),
         "2024-01-15T10:00:00Z", false, null);
 
@@ -145,32 +149,34 @@ public class AmazonPhotosClientTest {
     assertEquals("POST", request.getMethod());
     assertTrue(request.getPath().contains("name=test.jpg"));
     assertTrue(request.getPath().contains("kind=FILE"));
-    assertTrue(request.getPath().contains("conflictResolution=RENAME"));
     assertFalse(request.getPath().contains("visualCollectionParentNodeId"));
     assertEquals("md5hex", request.getHeader("x-amzn-file-md5"));
+    // conflictResolution is in the metadata JSON body, not query params
+    String body = request.getBody().readUtf8();
+    assertTrue(body.contains("RENAME"));
   }
 
   @Test
-  void uploadPhoto_includesParentNodeId() throws Exception {
+  void uploadContent_includesParentNodeId() throws Exception {
     server.takeRequest();
 
     server.enqueue(new MockResponse()
         .setBody("{\"id\":\"p1\",\"name\":\"pic.png\",\"kind\":\"FILE\"}"));
 
-    client.uploadPhoto("pic.png", tempFile, "md5", 1, null, false, "album1");
+    client.uploadContent("pic.png", tempFile, "md5", 1, null, false, "album1");
 
     RecordedRequest request = server.takeRequest();
     assertTrue(request.getPath().contains("visualCollectionParentNodeId=album1"));
   }
 
   @Test
-  void uploadPhoto_includesFavoriteSetting() throws Exception {
+  void uploadContent_includesFavoriteSetting() throws Exception {
     server.takeRequest();
 
     server.enqueue(new MockResponse()
         .setBody("{\"id\":\"f1\",\"name\":\"fav.jpg\",\"kind\":\"FILE\"}"));
 
-    client.uploadPhoto("fav.jpg", tempFile, "md5", 1, null, true, null);
+    client.uploadContent("fav.jpg", tempFile, "md5", 1, null, true, null);
 
     RecordedRequest request = server.takeRequest();
     assertTrue(request.getPath().contains("isFavorite=true"));
@@ -190,7 +196,7 @@ public class AmazonPhotosClientTest {
     server.takeRequest(); // 401
     server.takeRequest(); // token refresh
     RecordedRequest retryRequest = server.takeRequest();
-    assertEquals("new-token", retryRequest.getHeader("x-amz-access-token"));
+    assertEquals("Bearer new-token", retryRequest.getHeader("Authorization"));
   }
 
   @Test
@@ -206,14 +212,14 @@ public class AmazonPhotosClientTest {
   }
 
   @Test
-  void uploadPhoto_duplicateReturnsIOExceptionWith409() throws Exception {
+  void uploadContent_duplicateReturnsIOExceptionWith409() throws Exception {
     server.takeRequest();
 
     server.enqueue(new MockResponse().setResponseCode(409).setBody(
         "{\"errorCode\":\"DuplicatesConflictError\",\"errorDetails\":{\"conflictNodeIds\":[\"existingId\"]}}"));
 
     IOException ex = assertThrows(IOException.class,
-        () -> client.uploadPhoto("dup.jpg", tempFile, "md5", 1, null, false, "album1"));
+        () -> client.uploadContent("dup.jpg", tempFile, "md5", 1, null, false, "album1"));
 
     assertTrue(ex.getMessage().contains("409"));
     assertTrue(ex.getMessage().contains("DuplicatesConflictError"));
@@ -273,4 +279,459 @@ public class AmazonPhotosClientTest {
             + "\"contentUrl\":\"https://content.example.com\","
             + "\"uploadServiceUrl\":\"https://upload.example.com/\"}"));
   }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Multipart upload tests
+  // ─────────────────────────────────────────────────────────────────────────
+
+  private File createMultipartTestFile(int size) throws Exception {
+    File file = tempDir.resolve("multipart-test-" + size + ".bin").toFile();
+    byte[] data = new byte[size];
+    for (int i = 0; i < size; i++) { data[i] = (byte) (i % 256); }
+    Files.write(file.toPath(), data);
+    return file;
+  }
+
+  private void enqueueInitiateResponse(String nodeId, String uploadId, long partSize, int totalParts) {
+    server.enqueue(new MockResponse().setBody(String.format(
+        "{\"nodeId\":\"%s\",\"uploadId\":\"%s\",\"partSize\":%d,\"totalNumberOfParts\":%d}",
+        nodeId, uploadId, partSize, totalParts)));
+  }
+
+  private void enqueuePartResponse() {
+    server.enqueue(new MockResponse().setBody("{\"status\":\"UPLOAD_IN_PROGRESS\"}"));
+  }
+
+  private void enqueueCompleteResponse() {
+    server.enqueue(new MockResponse().setBody("{\"status\":\"UPLOAD_COMPLETING\"}"));
+  }
+
+  private void enqueuePollResponse(String status) {
+    server.enqueue(new MockResponse().setBody(String.format("{\"status\":\"%s\"}", status)));
+  }
+
+  @Test
+  void uploadContent_multipart_happyPath() throws Exception {
+    server.takeRequest(); // endpoint resolution
+    client.multipartThreshold = 10; // trigger multipart for files > 10 bytes
+
+    // File: 15 bytes, server says partSize=5, totalParts=3
+    File file = createMultipartTestFile(15);
+
+    enqueueInitiateResponse("node-mp1", "upload-123", 5, 3);
+    enqueuePartResponse(); // part 1
+    enqueuePartResponse(); // part 2
+    enqueuePartResponse(); // part 3
+    enqueueCompleteResponse();
+    enqueuePollResponse("UPLOAD_SUCCEEDED");
+
+    AmazonPhotosNode node = client.uploadContent(
+        "video.mp4", file, "md5hex", file.length(),
+        "2024-01-15T10:00:00Z", false, "album-1");
+
+    assertEquals("node-mp1", node.getId());
+
+    // Verify request sequence: initiate, 3 parts, complete, poll
+    RecordedRequest initReq = server.takeRequest();
+    assertEquals("POST", initReq.getMethod());
+    assertTrue(initReq.getPath().contains("multipart-upload"));
+    assertTrue(initReq.getPath().contains("name=video.mp4"));
+    assertTrue(initReq.getPath().contains("visualCollectionParentNodeId=album-1"));
+
+    for (int i = 1; i <= 3; i++) {
+      RecordedRequest partReq = server.takeRequest();
+      assertEquals("PUT", partReq.getMethod());
+      assertTrue(partReq.getPath().contains("/parts/" + i));
+      assertTrue(partReq.getPath().contains("uploadId=upload-123"));
+    }
+
+    RecordedRequest completeReq = server.takeRequest();
+    assertEquals("POST", completeReq.getMethod());
+    assertTrue(completeReq.getPath().contains("/complete"));
+
+    RecordedRequest pollReq = server.takeRequest();
+    assertEquals("GET", pollReq.getMethod());
+    assertTrue(pollReq.getPath().contains("node-mp1"));
+    assertTrue(pollReq.getPath().contains("uploadId=upload-123"));
+  }
+
+  @Test
+  void uploadContent_multipart_lastPartialPart() throws Exception {
+    server.takeRequest(); // endpoint
+    client.multipartThreshold = 10;
+
+    // File: 12 bytes, partSize=5, totalParts=3 → parts are 5, 5, 2
+    File file = createMultipartTestFile(12);
+
+    enqueueInitiateResponse("node-mp2", "upload-456", 5, 3);
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueueCompleteResponse();
+    enqueuePollResponse("UPLOAD_SUCCEEDED");
+
+    AmazonPhotosNode node = client.uploadContent(
+        "clip.mp4", file, "md5hex", file.length(),
+        "2024-01-15T10:00:00Z", false, null);
+
+    assertEquals("node-mp2", node.getId());
+
+    server.takeRequest(); // initiate
+    RecordedRequest part1 = server.takeRequest();
+    RecordedRequest part2 = server.takeRequest();
+    RecordedRequest part3 = server.takeRequest();
+
+    // Last part should be 2 bytes
+    assertTrue(part1.getPath().contains("partSize=5"));
+    assertTrue(part2.getPath().contains("partSize=5"));
+    assertTrue(part3.getPath().contains("partSize=2"));
+  }
+
+  @Test
+  void uploadContent_multipart_uploadFailed_throws() throws Exception {
+    server.takeRequest(); // endpoint
+    client.multipartThreshold = 5;
+
+    File file = createMultipartTestFile(10);
+
+    enqueueInitiateResponse("node-mp3", "upload-789", 5, 2);
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueueCompleteResponse();
+    enqueuePollResponse("UPLOAD_FAILED");
+
+    IOException ex = assertThrows(IOException.class, () ->
+        client.uploadContent("fail.mp4", file, "md5hex", file.length(),
+            "2024-01-15T10:00:00Z", false, null));
+
+    assertTrue(ex.getMessage().contains("Multipart upload failed"));
+  }
+
+  @Test
+  void uploadContent_multipart_completingThenSucceeds() throws Exception {
+    server.takeRequest(); // endpoint
+    client.multipartThreshold = 5;
+
+    File file = createMultipartTestFile(10);
+
+    enqueueInitiateResponse("node-mp4", "upload-abc", 5, 2);
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueueCompleteResponse();
+    // Server returns COMPLETING twice, then succeeds
+    enqueuePollResponse("UPLOAD_COMPLETING");
+    enqueuePollResponse("UPLOAD_COMPLETING");
+    enqueuePollResponse("UPLOAD_SUCCEEDED");
+
+    AmazonPhotosNode node = client.uploadContent(
+        "slow.mp4", file, "md5hex", file.length(),
+        "2024-01-15T10:00:00Z", false, null);
+
+    assertEquals("node-mp4", node.getId());
+  }
+
+  @Test
+  void uploadContent_multipart_inProgress_throwsImmediately() throws Exception {
+    server.takeRequest(); // endpoint
+    client.multipartThreshold = 5;
+
+    File file = createMultipartTestFile(10);
+
+    enqueueInitiateResponse("node-mp5", "upload-def", 5, 2);
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueueCompleteResponse();
+    enqueuePollResponse("UPLOAD_IN_PROGRESS");
+
+    IOException ex = assertThrows(IOException.class, () ->
+        client.uploadContent("inprog.mp4", file, "md5hex", file.length(),
+            "2024-01-15T10:00:00Z", false, null));
+
+    assertTrue(ex.getMessage().contains("UPLOAD_IN_PROGRESS"));
+    assertTrue(ex.getMessage().contains("Multipart upload failed"));
+  }
+
+  @Test
+  void uploadContent_multipart_aborted_throwsImmediately() throws Exception {
+    server.takeRequest(); // endpoint
+    client.multipartThreshold = 5;
+
+    File file = createMultipartTestFile(10);
+
+    enqueueInitiateResponse("node-mp6", "upload-ghi", 5, 2);
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueueCompleteResponse();
+    enqueuePollResponse("UPLOAD_ABORTED");
+
+    IOException ex = assertThrows(IOException.class, () ->
+        client.uploadContent("abort.mp4", file, "md5hex", file.length(),
+            "2024-01-15T10:00:00Z", false, null));
+
+    assertTrue(ex.getMessage().contains("UPLOAD_ABORTED"));
+  }
+
+  @Test
+  void uploadContent_multipart_expired_throwsImmediately() throws Exception {
+    server.takeRequest(); // endpoint
+    client.multipartThreshold = 5;
+
+    File file = createMultipartTestFile(10);
+
+    enqueueInitiateResponse("node-mp7", "upload-jkl", 5, 2);
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueueCompleteResponse();
+    enqueuePollResponse("UPLOAD_EXPIRED");
+
+    IOException ex = assertThrows(IOException.class, () ->
+        client.uploadContent("expire.mp4", file, "md5hex", file.length(),
+            "2024-01-15T10:00:00Z", false, null));
+
+    assertTrue(ex.getMessage().contains("UPLOAD_EXPIRED"));
+  }
+
+  @Test
+  void getMultipartUploadProgress_resumeSupport() throws Exception {
+    server.takeRequest(); // endpoint
+
+    server.enqueue(new MockResponse().setBody(
+        "{\"status\":\"UPLOAD_COMPLETING\",\"partSize\":1024,\"totalNumberOfParts\":5}"));
+
+    com.fasterxml.jackson.databind.JsonNode progress =
+        client.getMultipartUploadProgress("resume-node", "resume-upload");
+
+    assertEquals("UPLOAD_COMPLETING", progress.get("status").asText());
+    assertEquals(5, progress.get("totalNumberOfParts").asInt());
+  }
+
+  @Test
+  void uploadContent_multipart_transientProgressError_retriesUntilSuccess() throws Exception {
+    server.takeRequest(); // endpoint
+    client.multipartThreshold = 5;
+    client.initialPollDelayMs = 0;
+
+    File file = createMultipartTestFile(10);
+
+    enqueueInitiateResponse("node-mp8", "upload-mno", 5, 2);
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueueCompleteResponse();
+    // First progress check errors (500); the upload must not fail -- it should keep polling.
+    server.enqueue(new MockResponse().setResponseCode(500).setBody("{\"message\":\"transient\"}"));
+    enqueuePollResponse("UPLOAD_SUCCEEDED");
+
+    AmazonPhotosNode node = client.uploadContent(
+        "retry.mp4", file, "md5hex", file.length(),
+        "2024-01-15T10:00:00Z", false, null);
+
+    assertEquals("node-mp8", node.getId());
+  }
+
+  @Test
+  void uploadContent_multipart_progressCheck4xx_failsFast() throws Exception {
+    server.takeRequest(); // endpoint
+    client.multipartThreshold = 5;
+
+    File file = createMultipartTestFile(10);
+
+    enqueueInitiateResponse("node-mp9", "upload-pqr", 5, 2);
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueueCompleteResponse();
+    // Progress check returns a definitive 4xx -> must fail fast (only one poll enqueued);
+    // if it wrongly retried, the test would block waiting for more responses.
+    server.enqueue(new MockResponse().setResponseCode(404).setBody(
+        "{\"errorCode\":\"MultipartUploadNotFound\"}"));
+
+    IOException ex = assertThrows(IOException.class, () ->
+        client.uploadContent("nf.mp4", file, "md5hex", file.length(),
+            "2024-01-15T10:00:00Z", false, null));
+
+    assertTrue(ex.getMessage().contains("404"));
+  }
+
+  @Test
+  void uploadContent_multipart_missingStatusField_retriesUntilSuccess() throws Exception {
+    server.takeRequest(); // endpoint
+    client.multipartThreshold = 5;
+    client.initialPollDelayMs = 0;
+
+    File file = createMultipartTestFile(10);
+
+    enqueueInitiateResponse("node-mp10", "upload-stu", 5, 2);
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueueCompleteResponse();
+    // 2xx but no "status" field -> malformed; must be retried (not NPE out of the poll loop).
+    server.enqueue(new MockResponse().setBody("{}"));
+    enqueuePollResponse("UPLOAD_SUCCEEDED");
+
+    AmazonPhotosNode node = client.uploadContent(
+        "ms.mp4", file, "md5hex", file.length(),
+        "2024-01-15T10:00:00Z", false, null);
+
+    assertEquals("node-mp10", node.getId());
+  }
+
+  @Test
+  void error_logsErrorCodeAndMessageTogether() throws Exception {
+    server.takeRequest(); // endpoint
+
+    server.enqueue(new MockResponse().setResponseCode(403).setBody(
+        "{\"errorCode\":\"ForbiddenAccess\",\"message\":\"App not authorized\"}"));
+
+    IOException ex = assertThrows(IOException.class, () -> client.createAlbum("test"));
+
+    assertTrue(ex.getMessage().contains("403"));
+    assertTrue(ex.getMessage().contains("ForbiddenAccess"));
+    assertTrue(ex.getMessage().contains("App not authorized"));
+  }
+
+  @Test
+  void createDefaultHttpClient_hasConfiguredTimeouts() {
+    OkHttpClient c = AmazonPhotosClient.createDefaultHttpClient();
+    assertEquals(30000, c.connectTimeoutMillis());
+    assertEquals(60000, c.readTimeoutMillis());
+    assertEquals(30000, c.writeTimeoutMillis());
+  }
+
+  @Test
+  void resolveEndpoints_missingUploadServiceUrl_throwsIncomplete() throws Exception {
+    OkHttpClient httpClient = new OkHttpClient.Builder()
+        .addInterceptor(chain -> {
+          okhttp3.HttpUrl newUrl = chain.request().url().newBuilder()
+              .scheme("http").host(server.getHostName()).port(server.getPort()).build();
+          return chain.proceed(chain.request().newBuilder().url(newUrl).build());
+        })
+        .build();
+    AmazonPhotosClient freshClient = new AmazonPhotosClient(
+        httpClient, ACCESS_TOKEN, REFRESH_TOKEN, CLIENT_ID, CLIENT_SECRET);
+    server.takeRequest(); // consume the setUp endpoint request
+
+    // metadataUrl present but uploadServiceUrl absent -> resolution is incomplete.
+    server.enqueue(new MockResponse().setBody(
+        "{\"metadataUrl\":\"https://meta.example.com/v1\",\"contentUrl\":\"https://c.example.com\"}"));
+
+    IOException ex = assertThrows(IOException.class, freshClient::resolveEndpoints);
+    assertTrue(ex.getMessage().contains("incomplete"));
+  }
+
+  @Test
+  void error_nonJsonBody_reportsStatusOnly() throws Exception {
+    server.takeRequest(); // endpoint
+
+    server.enqueue(new MockResponse().setResponseCode(500).setBody("not-json"));
+
+    IOException ex = assertThrows(IOException.class, () -> client.createAlbum("test"));
+
+    assertTrue(ex.getMessage().contains("500"));
+    // Body is not JSON, so errorCode/message cannot be extracted and are omitted.
+    assertFalse(ex.getMessage().contains("errorCode"));
+  }
+
+  @Test
+  void uploadContent_multipart_completingBudgetExhausted_throws() throws Exception {
+    server.takeRequest(); // endpoint
+    client.multipartThreshold = 5;
+    client.pollMaxRetries = 2;
+    client.initialPollDelayMs = 0;
+
+    File file = createMultipartTestFile(10);
+
+    enqueueInitiateResponse("node-be1", "upload-be1", 5, 2);
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueueCompleteResponse();
+    enqueuePollResponse("UPLOAD_COMPLETING");
+    enqueuePollResponse("UPLOAD_COMPLETING");
+
+    IOException ex = assertThrows(IOException.class, () ->
+        client.uploadContent("be.mp4", file, "md5hex", file.length(),
+            "2024-01-15T10:00:00Z", false, null));
+
+    assertTrue(ex.getMessage().contains("did not complete within 2 retries"));
+  }
+
+  @Test
+  void uploadContent_multipart_transientProgressBudgetExhausted_throws() throws Exception {
+    server.takeRequest(); // endpoint
+    client.multipartThreshold = 5;
+    client.pollMaxRetries = 2;
+    client.initialPollDelayMs = 0;
+
+    File file = createMultipartTestFile(10);
+
+    enqueueInitiateResponse("node-be2", "upload-be2", 5, 2);
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueueCompleteResponse();
+    // Progress check keeps returning 500 (transient) -> retried until budget is exhausted.
+    server.enqueue(new MockResponse().setResponseCode(500).setBody("{\"message\":\"ise\"}"));
+    server.enqueue(new MockResponse().setResponseCode(500).setBody("{\"message\":\"ise\"}"));
+
+    IOException ex = assertThrows(IOException.class, () ->
+        client.uploadContent("be2.mp4", file, "md5hex", file.length(),
+            "2024-01-15T10:00:00Z", false, null));
+
+    assertTrue(ex.getMessage().contains("progress check did not succeed within 2 retries"));
+  }
+
+  @Test
+  void uploadContent_multipart_isFavorite_addsFavoriteParam() throws Exception {
+    server.takeRequest(); // endpoint
+    client.multipartThreshold = 5;
+    client.initialPollDelayMs = 0;
+
+    File file = createMultipartTestFile(10);
+
+    enqueueInitiateResponse("node-fav", "upload-fav", 5, 2);
+    enqueuePartResponse();
+    enqueuePartResponse();
+    enqueueCompleteResponse();
+    enqueuePollResponse("UPLOAD_SUCCEEDED");
+
+    client.uploadContent("fav.mp4", file, "md5hex", file.length(),
+        "2024-01-15T10:00:00Z", true, null);
+
+    RecordedRequest init = server.takeRequest();
+    assertTrue(init.getPath().contains("isFavorite=true"));
+  }
+
+  @Test
+  void error_emptyBody_reportsStatusOnly() throws Exception {
+    server.takeRequest(); // endpoint
+
+    server.enqueue(new MockResponse().setResponseCode(500)); // no body -> ""
+
+    IOException ex = assertThrows(IOException.class, () -> client.createAlbum("test"));
+
+    assertTrue(ex.getMessage().contains("500"));
+    assertFalse(ex.getMessage().contains("errorCode"));
+  }
+
+  @Test
+  void createAlbum_resolvesEndpointsLazilyWhenNotYetResolved() throws Exception {
+    OkHttpClient httpClient = new OkHttpClient.Builder()
+        .addInterceptor(chain -> {
+          okhttp3.HttpUrl newUrl = chain.request().url().newBuilder()
+              .scheme("http").host(server.getHostName()).port(server.getPort()).build();
+          return chain.proceed(chain.request().newBuilder().url(newUrl).build());
+        })
+        .build();
+    // Fresh client: resolveEndpoints() has NOT been called explicitly.
+    AmazonPhotosClient freshClient = new AmazonPhotosClient(
+        httpClient, ACCESS_TOKEN, REFRESH_TOKEN, CLIENT_ID, CLIENT_SECRET);
+    server.takeRequest(); // consume the setUp endpoint request
+
+    enqueueEndpointResponse(); // served by the lazy ensureEndpointsResolved()
+    server.enqueue(new MockResponse().setBody("{\"id\":\"n1\",\"name\":\"Lazy\"}"));
+
+    AmazonPhotosNode node = freshClient.createAlbum("Lazy");
+
+    assertEquals("n1", node.getId());
+    RecordedRequest endpointReq = server.takeRequest();
+    assertTrue(endpointReq.getPath().contains("/drive/v1/account/endpoint"));
+  }
+
 }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosImporterTest.java
@@ -18,8 +18,11 @@ package org.datatransferproject.transfer.amazon.photos;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,6 +34,10 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
+import org.datatransferproject.transfer.JobMetadata;
+import org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode;
+import org.datatransferproject.types.common.models.FavoriteInfo;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
@@ -39,6 +46,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
@@ -53,6 +61,7 @@ public class AmazonPhotosImporterTest {
   @Mock private Monitor monitor;
   @Mock private TemporaryPerJobDataStore dataStore;
   @Mock private IdempotentImportExecutor executor;
+  @Mock private IdempotentImportExecutor retryingExecutor;
   @Mock private AmazonPhotosInterface client;
 
   private TokensAndUrlAuthData authData;
@@ -92,7 +101,13 @@ public class AmazonPhotosImporterTest {
     ImportResult result = importer.importItem(jobId, executor, authData, resource);
 
     assertEquals(ImportResult.OK, result);
-    // Verify album + 2 photos registered with executor
+    // Album + both photos are registered with the executor under their own keys/names.
+    verify(executor).executeAndSwallowIOExceptions(eq("a1"), eq("Album"), any());
+    verify(executor).executeAndSwallowIOExceptions(
+        eq(photo1.getIdempotentId()), eq("pic1.jpg"), any());
+    verify(executor).executeAndSwallowIOExceptions(
+        eq(photo2.getIdempotentId()), eq("pic2.jpg"), any());
+    // ...and nothing else.
     verify(executor, times(3)).executeAndSwallowIOExceptions(any(), any(), any());
   }
 
@@ -146,7 +161,7 @@ public class AmazonPhotosImporterTest {
         Collections.emptyList(), Collections.singletonList(photo));
 
     InputStream fakeStream = new java.io.ByteArrayInputStream(new byte[]{1, 2, 3});
-    when(dataStore.getStream(any(), eq("tempkey")))
+    when(dataStore.getStream(eq(jobId), eq("tempkey")))
         .thenReturn(new TemporaryPerJobDataStore.InputStreamWrapper(fakeStream));
     File tempFile = File.createTempFile("test", ".tmp");
     tempFile.deleteOnExit();
@@ -156,8 +171,7 @@ public class AmazonPhotosImporterTest {
           java.util.concurrent.Callable<?> callable = invocation.getArgument(2);
           return callable.call();
         });
-    when(executor.isKeyCached(any())).thenReturn(false);
-    when(client.uploadPhoto(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
+    when(client.uploadContent(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
         .thenReturn(new org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode());
 
     importer.importItem(jobId, executor, authData, resource);
@@ -207,7 +221,7 @@ public class AmazonPhotosImporterTest {
         Collections.emptyList(), Collections.singletonList(photo));
 
     InputStream fakeStream = new java.io.ByteArrayInputStream(new byte[]{1, 2, 3});
-    when(dataStore.getStream(any(), eq("tempkey")))
+    when(dataStore.getStream(eq(jobId), eq("tempkey")))
         .thenReturn(new TemporaryPerJobDataStore.InputStreamWrapper(fakeStream));
     File tempFile = File.createTempFile("test", ".tmp");
     tempFile.deleteOnExit();
@@ -217,8 +231,7 @@ public class AmazonPhotosImporterTest {
           java.util.concurrent.Callable<?> callable = invocation.getArgument(2);
           return callable.call();
         });
-    when(executor.isKeyCached(any())).thenReturn(false);
-    when(client.uploadPhoto(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
+    when(client.uploadContent(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
         .thenReturn(new org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode());
 
     importer.importItem(jobId, executor, authData, resource);
@@ -273,5 +286,216 @@ public class AmazonPhotosImporterTest {
   @Test
   void downloadToTempFile_dotSegmentsWithoutSeparatorInDataId_isContained() throws Exception {
     assertPrefixIsContained(captureTempPrefixForDataId("....etc....passwd"));
+  }
+
+  // Verifies that if album creation failed, photo upload also fails rather than
+  // silently uploading without album (preventing data loss of album organization).
+  @Test
+  void importItem_albumCreationFailed_photoUploadAlsoFails() throws Exception {
+    PhotoModel photo = new PhotoModel("pic.jpg", "tempkey",
+        null, "image/jpeg", "photo-1", "failed-album", true, (Date) null);
+
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.emptyList(), Collections.singletonList(photo));
+
+    when(executor.getCachedValue("failed-album"))
+        .thenThrow(new IllegalStateException("Album creation failed"));
+    when(executor.executeAndSwallowIOExceptions(any(), any(), any()))
+        .thenAnswer(invocation -> {
+          java.util.concurrent.Callable<?> callable = invocation.getArgument(2);
+          try {
+            return callable.call();
+          } catch (Exception e) {
+            return null;
+          }
+        });
+
+    importer.importItem(jobId, executor, authData, resource);
+
+    verify(client, never())
+        .uploadContent(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Retrying-executor selection (platform retry opt-in).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void importItem_usesRetryingExecutorWhenEnabled() throws Exception {
+    AmazonPhotosImporter retryingImporter =
+        new AmazonPhotosImporter(monitor, dataStore, client, retryingExecutor, true);
+    PhotoAlbum album = new PhotoAlbum("a1", "Album", null);
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.singletonList(album), Collections.emptyList());
+
+    retryingImporter.importItem(jobId, executor, authData, resource);
+
+    verify(retryingExecutor).executeAndSwallowIOExceptions(eq("a1"), eq("Album"), any());
+    verifyNoInteractions(executor);
+  }
+
+  @Test
+  void importItem_usesDefaultExecutorWhenRetryingDisabled() throws Exception {
+    AmazonPhotosImporter retryingImporter =
+        new AmazonPhotosImporter(monitor, dataStore, client, retryingExecutor, false);
+    PhotoAlbum album = new PhotoAlbum("a1", "Album", null);
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.singletonList(album), Collections.emptyList());
+
+    retryingImporter.importItem(jobId, executor, authData, resource);
+
+    verify(executor).executeAndSwallowIOExceptions(eq("a1"), eq("Album"), any());
+    verifyNoInteractions(retryingExecutor);
+  }
+
+  @Test
+  void importItem_usesDefaultExecutorWhenNoRetryingExecutorProvided() throws Exception {
+    AmazonPhotosImporter retryingImporter =
+        new AmazonPhotosImporter(monitor, dataStore, client, null, true);
+    PhotoAlbum album = new PhotoAlbum("a1", "Album", null);
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.singletonList(album), Collections.emptyList());
+
+    retryingImporter.importItem(jobId, executor, authData, resource);
+
+    verify(executor).executeAndSwallowIOExceptions(eq("a1"), eq("Album"), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Storage-quota classification -> terminal DestinationMemoryFullException.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void importItem_noActiveSubscription_throwsDestinationMemoryFull() throws Exception {
+    PhotoModel photo = new PhotoModel("pic.jpg", "tempkey",
+        null, "image/jpeg", "p1", null, true, (Date) null);
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.emptyList(), Collections.singletonList(photo));
+
+    InputStream fakeStream = new java.io.ByteArrayInputStream(new byte[]{1, 2, 3});
+    when(dataStore.getStream(eq(jobId), eq("tempkey")))
+        .thenReturn(new TemporaryPerJobDataStore.InputStreamWrapper(fakeStream));
+    File tempFile = File.createTempFile("test", ".tmp");
+    tempFile.deleteOnExit();
+    when(dataStore.getTempFileFromInputStream(any(), any(), any())).thenReturn(tempFile);
+    when(executor.executeAndSwallowIOExceptions(any(), any(), any()))
+        .thenAnswer(invocation -> {
+          java.util.concurrent.Callable<?> callable = invocation.getArgument(2);
+          return callable.call();
+        });
+    when(client.uploadContent(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
+        .thenThrow(new AmazonPhotosApiException(403, "NoActiveSubscriptionFound", "no subscription"));
+
+    assertThrows(DestinationMemoryFullException.class,
+        () -> importer.importItem(jobId, executor, authData, resource));
+  }
+
+  // ---------------------------------------------------------------------------
+  // createAlbum body (requires the JobMetadata worker singleton, mocked statically).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void importItem_createAlbum_invokesClientWithSuffixedNameAndReturnsId() throws Exception {
+    PhotoAlbum album = new PhotoAlbum("a1", "Vacation", "desc");
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.singletonList(album), Collections.emptyList());
+
+    AmazonPhotosNode node = new AmazonPhotosNode();
+    node.setId("amazon-album-1");
+    when(client.createAlbum(any())).thenReturn(node);
+    executorRunsCallable();
+
+    try (MockedStatic<JobMetadata> jm = mockStatic(JobMetadata.class)) {
+      jm.when(JobMetadata::getExportService).thenReturn("Google");
+      importer.importItem(jobId, executor, authData, resource);
+    }
+
+    org.mockito.ArgumentCaptor<String> name = org.mockito.ArgumentCaptor.forClass(String.class);
+    verify(client).createAlbum(name.capture());
+    assertEquals("Vacation" + AmazonImportHelper.IMPORTED_SUFFIX + "Google", name.getValue());
+  }
+
+  // ---------------------------------------------------------------------------
+  // uploadPhoto happy path (covers uploadedTime + favorite mapping, upload, temp cleanup).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void importItem_uploadPhoto_happyPath_withUploadedTimeAndFavorite() throws Exception {
+    Date uploaded = new Date(1_700_000_000_000L);
+    PhotoModel photo = new PhotoModel("pic.jpg", "tempkey", null, "image/jpeg",
+        "p1", null, true, null, uploaded, new FavoriteInfo(true, uploaded));
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.emptyList(), Collections.singletonList(photo));
+
+    stubDownload();
+    executorRunsCallable();
+    AmazonPhotosNode node = new AmazonPhotosNode();
+    node.setId("uploaded-1");
+    when(client.uploadContent(eq("pic.jpg"), any(), any(), any(Long.class),
+        eq(uploaded.toInstant().toString()), eq(true), eq(null))).thenReturn(node);
+
+    importer.importItem(jobId, executor, authData, resource);
+
+    verify(client).uploadContent(eq("pic.jpg"), any(), any(), any(Long.class),
+        eq(uploaded.toInstant().toString()), eq(true), eq(null));
+    // inTempStore == true -> temp data is cleaned up after upload.
+    verify(dataStore).removeData(jobId, "tempkey");
+  }
+
+  @Test
+  void importItem_uploadPhoto_duplicate_isSkippedWithoutError() throws Exception {
+    PhotoModel photo = new PhotoModel("pic.jpg", "tempkey",
+        null, "image/jpeg", "p1", null, true, (Date) null);
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.emptyList(), Collections.singletonList(photo));
+
+    stubDownload();
+    executorRunsCallable();
+    when(client.uploadContent(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
+        .thenThrow(new AmazonPhotosApiException(409, "DuplicatesConflictError", "dup"));
+
+    // Duplicate is swallowed as success -> importItem completes without throwing.
+    ImportResult result = importer.importItem(jobId, executor, authData, resource);
+
+    assertEquals(ImportResult.OK, result);
+    verify(client).uploadContent(eq("pic.jpg"), any(), any(), any(Long.class), any(), any(Boolean.class), any());
+  }
+
+  @Test
+  void importItem_uploadPhoto_nonDuplicateNonQuotaError_propagates() throws Exception {
+    PhotoModel photo = new PhotoModel("pic.jpg", "tempkey",
+        null, "image/jpeg", "p1", null, true, (Date) null);
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.emptyList(), Collections.singletonList(photo));
+
+    stubDownload();
+    executorRunsCallable();
+    when(client.uploadContent(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
+        .thenThrow(new AmazonPhotosApiException(403, "ForbiddenAccess", "denied"));
+
+    assertThrows(AmazonPhotosApiException.class,
+        () -> importer.importItem(jobId, executor, authData, resource));
+  }
+
+  @Test
+  void productionConstructor_buildsWithoutNetwork() {
+    // Exercises the production wiring; the client is built lazily per job, not at construction.
+    assertNotNull(new AmazonPhotosImporter(
+        monitor, "client-id", "client-secret", dataStore, null, false));
+  }
+
+  private void stubDownload() throws Exception {
+    InputStream stream = new java.io.ByteArrayInputStream(new byte[]{1, 2, 3});
+    when(dataStore.getStream(eq(jobId), eq("tempkey")))
+        .thenReturn(new TemporaryPerJobDataStore.InputStreamWrapper(stream));
+    File tempFile = File.createTempFile("test", ".tmp");
+    tempFile.deleteOnExit();
+    when(dataStore.getTempFileFromInputStream(any(), any(), any())).thenReturn(tempFile);
+  }
+
+  private void executorRunsCallable() throws Exception {
+    when(executor.executeAndSwallowIOExceptions(any(), any(), any()))
+        .thenAnswer(invocation ->
+            ((java.util.concurrent.Callable<?>) invocation.getArgument(2)).call());
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/RetryUtilsTest.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/RetryUtilsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class RetryUtilsTest {
+
+  @Test
+  void computeBackoffMillis_attempt1_around1Second() {
+    // attempt=1: base = min(2^0, 60) = 1s, with jitter [1.0, 1.3) → [1000, 1300]ms
+    long backoff = RetryUtils.computeBackoffMillis(1, 60.0);
+    assertTrue(backoff >= 1000 && backoff <= 1300,
+        "Expected [1000,1300] but got " + backoff);
+  }
+
+  @Test
+  void computeBackoffMillis_attempt5_exponential16Seconds() {
+    // attempt=5: base = min(2^4, 60) = 16s, with jitter [1.0, 1.3) → [16000, 20800]ms
+    long backoff = RetryUtils.computeBackoffMillis(5, 60.0);
+    assertTrue(backoff >= 16000 && backoff <= 20800,
+        "Expected [16000,20800] but got " + backoff);
+  }
+
+  @Test
+  void computeBackoffMillis_attempt7_reachesCap() {
+    // attempt=7: base = min(2^6=64, 60) = 60s (capped), with jitter → [60000, 78000]ms
+    long backoff = RetryUtils.computeBackoffMillis(7, 60.0);
+    assertTrue(backoff >= 60000 && backoff <= 78000,
+        "Expected [60000,78000] but got " + backoff);
+  }
+
+  @Test
+  void computeBackoffMillis_attempt10_stillCappedAt60Seconds() {
+    // attempt=10: base = min(2^9=512, 60) = 60s (capped), with jitter [60000, 78000]ms
+    long backoff = RetryUtils.computeBackoffMillis(10, 60.0);
+    assertTrue(backoff >= 60000 && backoff <= 78000,
+        "Expected [60000,78000] but got " + backoff);
+  }
+
+  @Test
+  void sleep_notInterrupted_sleeps() throws Exception {
+    long start = System.currentTimeMillis();
+    RetryUtils.sleep(50);
+    long elapsed = System.currentTimeMillis() - start;
+    assertTrue(elapsed >= 40, "Should have slept ~50ms but only " + elapsed + "ms");
+  }
+
+  @Test
+  void sleep_interrupted_throwsIOException() throws Exception {
+    Thread testThread = Thread.currentThread();
+
+    // Interrupt from another thread after a short delay
+    new Thread(() -> {
+      try { Thread.sleep(30); } catch (InterruptedException e) { }
+      testThread.interrupt();
+    }).start();
+
+    IOException ex = assertThrows(IOException.class, () -> RetryUtils.sleep(2000));
+    assertTrue(ex.getMessage().contains("interrupted"));
+    // Clear interrupt flag
+    Thread.interrupted();
+  }
+}


### PR DESCRIPTION
## Summary

Refactors the Amazon Photos importer for reliability and testability. Introduces typed API error handling, structured failure classification, platform-level retry integration, and multipart upload with robust completion polling. Client lifecycle and shared import utilities are extracted into a new `AmazonImportHelper`.

> **Note:** This PR has been reviewed internally already.

This is a behavior-preserving refactor for existing flows, plus hardening for transient failures and large uploads.

## What's changed

### Error handling

- New `AmazonPhotosApiException` carrying HTTP status + service `errorCode`. The client parses the error body and throws the typed exception, logging only `errorCode`/`message` (never the raw response body).
- `UploadErrorCodes` centralizes the client-facing codes we classify on:
  - Duplicates (`DuplicatesConflictError`) are skipped idempotently.
  - Storage-quota conditions (`InsufficientStorage`, `NoActiveSubscriptionFound`) map to a terminal `DestinationMemoryFullException`.

### Retry integration

- Wires the platform `RetryingIdempotentImportExecutor` (opt-in via the `enableRetrying` setting) so transient failures are retried per the host `RetryStrategyLibrary`, consistent with other providers.

### Multipart upload

- Initiate → upload parts → complete, followed by completion polling that:
  - fails fast on a definitive 4xx,
  - retries transient 5xx/429/malformed responses until the budget is exhausted, and
  - guards against a missing status field.
- `RetryUtils` backoff is exponential-with-jitter; explicit connect/read/write timeouts on the OkHttp client.

### Shared `AmazonImportHelper`

- Owns per-job client creation keyed by `jobId` (bounded access-order LRU), resolving endpoints once per job. Client build + endpoint resolution happen outside the lock so one job's latency can't stall others.
- Provides MD5/streamed download (untrusted `dataId` is sanitized for the temp-file prefix) and the shared error classification used by the importer.
- Endpoint resolution now requires `uploadServiceUrl` (dropped the `contentUrl` fallback).

## Testing

Unit tests added/updated across:

- **Helper** — per-job client isolation, error classification.
- **Client** — multipart poll success / fail-fast / transient-retry / budget-exhausted, error extraction, configured timeouts, lazy endpoint resolution.
- **Importer** — retry-executor selection, quota → terminal failure, duplicate skip, upload happy paths.

Completed transfers and validated.

## Notes

- `okhttp`/`mockwebserver` now use the shared `${okHttpVersion}` instead of a hardcoded version.