### PR TITLE
feat(amazon-photos): add Media vertical importer

### DIFF
--- a/extensions/auth/portability-auth-amazon/src/main/java/org/datatransferproject/auth/amazon/AmazonOAuthConfig.java
+++ b/extensions/auth/portability-auth-amazon/src/main/java/org/datatransferproject/auth/amazon/AmazonOAuthConfig.java
@@ -8,6 +8,7 @@ import org.datatransferproject.types.common.models.DataVertical;
 import java.util.Map;
 import java.util.Set;
 
+import static org.datatransferproject.types.common.models.DataVertical.MEDIA;
 import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
 import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
 
@@ -41,6 +42,13 @@ public class AmazonOAuthConfig implements OAuth2Config {
         VIDEOS, ImmutableSet.of(
             "amazonphotos::videos:create",
             "amazonphotos::albums:create",
+            "amazonphotos::albums:update"),
+        // MEDIA is the unified vertical (photos + videos + albums), so it needs the union of the
+        // image, video and album scopes.
+        MEDIA, ImmutableSet.of(
+            "amazonphotos::images:create",
+            "amazonphotos::videos:create",
+            "amazonphotos::albums:create",
             "amazonphotos::albums:update"));
   }
 
@@ -51,6 +59,12 @@ public class AmazonOAuthConfig implements OAuth2Config {
             "amazonphotos::images:read",
             "amazonphotos::albums:read"),
         VIDEOS, ImmutableSet.of(
+            "amazonphotos::videos:read",
+            "amazonphotos::albums:read"),
+        // MEDIA is the unified vertical (photos + videos + albums); declare the union so the auth
+        // framework can build import/export generators symmetrically with PHOTOS/VIDEOS.
+        MEDIA, ImmutableSet.of(
+            "amazonphotos::images:read",
             "amazonphotos::videos:read",
             "amazonphotos::albums:read"));
   }

--- a/extensions/auth/portability-auth-amazon/src/test/java/org/datatransferproject/auth/amazon/AmazonOAuthConfigTest.java
+++ b/extensions/auth/portability-auth-amazon/src/test/java/org/datatransferproject/auth/amazon/AmazonOAuthConfigTest.java
@@ -1,6 +1,7 @@
 package org.datatransferproject.auth.amazon;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.datatransferproject.types.common.models.DataVertical.MEDIA;
 import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
 import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
 
@@ -50,6 +51,17 @@ class AmazonOAuthConfigTest {
   }
 
   @Test
+  void importScopesForMedia() {
+    // MEDIA is the unified vertical, so it requests the union of image, video and album scopes.
+    assertThat(config.getImportScopes().get(MEDIA))
+        .containsExactly(
+            "amazonphotos::images:create",
+            "amazonphotos::videos:create",
+            "amazonphotos::albums:create",
+            "amazonphotos::albums:update");
+  }
+
+  @Test
   void exportScopesForPhotos() {
     assertThat(config.getExportScopes().get(PHOTOS))
         .containsExactly("amazonphotos::images:read", "amazonphotos::albums:read");
@@ -59,5 +71,14 @@ class AmazonOAuthConfigTest {
   void exportScopesForVideos() {
     assertThat(config.getExportScopes().get(VIDEOS))
         .containsExactly("amazonphotos::videos:read", "amazonphotos::albums:read");
+  }
+
+  @Test
+  void exportScopesForMedia() {
+    assertThat(config.getExportScopes().get(MEDIA))
+        .containsExactly(
+            "amazonphotos::images:read",
+            "amazonphotos::videos:read",
+            "amazonphotos::albums:read");
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/AmazonTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/AmazonTransferExtension.java
@@ -26,6 +26,7 @@ import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportE
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.transfer.amazon.photos.AmazonMediaImporter;
 import org.datatransferproject.transfer.amazon.photos.AmazonPhotosImporter;
 import org.datatransferproject.transfer.amazon.photos.AmazonVideosImporter;
 import org.datatransferproject.types.common.models.DataVertical;
@@ -39,6 +40,7 @@ public class AmazonTransferExtension implements TransferExtension {
 
   private AmazonPhotosImporter photosImporter;
   private AmazonVideosImporter videosImporter;
+  private AmazonMediaImporter mediaImporter;
   private volatile boolean initialized = false;
 
   @Override
@@ -59,6 +61,8 @@ public class AmazonTransferExtension implements TransferExtension {
       return photosImporter;
     } else if (transferDataType == DataVertical.VIDEOS) {
       return videosImporter;
+    } else if (transferDataType == DataVertical.MEDIA) {
+      return mediaImporter;
     }
     throw new IllegalArgumentException("Unsupported data type: " + transferDataType);
   }
@@ -89,6 +93,11 @@ public class AmazonTransferExtension implements TransferExtension {
         retryingIdempotentExecutor, enableRetrying);
 
     videosImporter = new AmazonVideosImporter(
+        monitor, appCredentials.getKey(), appCredentials.getSecret(),
+        context.getService(TemporaryPerJobDataStore.class),
+        retryingIdempotentExecutor, enableRetrying);
+
+    mediaImporter = new AmazonMediaImporter(
         monitor, appCredentials.getKey(), appCredentials.getSecret(),
         context.getService(TemporaryPerJobDataStore.class),
         retryingIdempotentExecutor, enableRetrying);

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonImportHelper.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonImportHelper.java
@@ -20,6 +20,9 @@ import org.datatransferproject.spi.cloud.connection.ConnectionProvider;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
+import org.datatransferproject.transfer.JobMetadata;
+import org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode;
 import org.datatransferproject.types.common.DownloadableItem;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
@@ -28,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -72,8 +76,9 @@ class AmazonImportHelper {
   }
 
   /** Test helper: {@code injectedClient} is always returned by {@link #getOrCreateClient}. */
-  AmazonImportHelper(TemporaryPerJobDataStore dataStore, AmazonPhotosInterface injectedClient) {
-    this(dataStore, null, null, null, injectedClient);
+  AmazonImportHelper(TemporaryPerJobDataStore dataStore, AmazonPhotosInterface injectedClient,
+                     Monitor monitor) {
+    this(dataStore, null, null, monitor, injectedClient);
   }
 
   private AmazonImportHelper(TemporaryPerJobDataStore dataStore, String clientId,
@@ -179,5 +184,68 @@ class AmazonImportHelper {
   /** Removes temp data from the job store. */
   void cleanupTempData(UUID jobId, String fetchableUrl) throws IOException {
     dataStore.removeData(jobId, fetchableUrl);
+  }
+
+  /**
+   * Creates an album named for the source service (e.g. "Trips - Imported from Google") and
+   * returns its Amazon node id. Shared by the photos, videos and media importers, which differ
+   * only in their album model type.
+   */
+  String createAlbum(AmazonPhotosInterface client, String albumId, String albumName)
+      throws IOException {
+    String name = albumName + IMPORTED_SUFFIX + JobMetadata.getExportService();
+    AmazonPhotosNode node = client.createAlbum(name);
+    monitor.info(() -> "Created album " + albumId + " -> " + node.getId());
+    return node.getId();
+  }
+
+  /**
+   * Downloads an item to a temp file (computing MD5 in a single pass), uploads it via the client,
+   * and cleans up. Shared by the photos, videos and media importers; the per-vertical values are
+   * carried by {@link UploadItemRequest}.
+   *
+   * <p>Returns the uploaded node id, or the item's {@code dataId} when the destination reports the
+   * content already exists (duplicate — skipped as success). A storage-quota error is rethrown as
+   * the terminal {@link DestinationMemoryFullException}; any other API error propagates.
+   */
+  String uploadItem(AmazonPhotosInterface client, UUID jobId, UploadItemRequest req,
+                    IdempotentImportExecutor executor) throws Exception {
+    String targetAlbumId = resolveTargetAlbumId(req.albumId, executor);
+    MessageDigest md5 = newMd5Digest();
+    File tempFile = downloadToTempFile(jobId, req.item, req.dataId, md5);
+
+    try {
+      String md5Hex = toHexString(md5.digest());
+      long fileSize = tempFile.length();
+      String fallbackContentDate = req.uploadedTime != null
+          ? req.uploadedTime.toInstant().toString()
+          : Instant.now().toString();
+
+      AmazonPhotosNode uploadedNode = client.uploadContent(
+          req.displayName, tempFile, md5Hex, fileSize, fallbackContentDate, req.isFavorite,
+          targetAlbumId);
+      return uploadedNode.getId();
+
+    } catch (AmazonPhotosApiException e) {
+      if (isDuplicate(e)) {
+        monitor.info(() -> "Duplicate item skipped: " + req.dataId);
+        return req.dataId;
+      }
+      if (isStorageQuotaExceeded(e)) {
+        throw new DestinationMemoryFullException("Amazon Photos storage full", e);
+      }
+      throw e;
+    } finally {
+      tempFile.delete();
+      if (req.item.isInTempStore()) {
+        try {
+          cleanupTempData(jobId, req.item.getFetchableUrl());
+        } catch (IOException cleanupError) {
+          // Best-effort cleanup: don't let it mask the real upload outcome (e.g. a terminal
+          // DestinationMemoryFullException) by throwing out of the finally block.
+          monitor.info(() -> "Failed to clean up temp data for " + req.dataId, cleanupError);
+        }
+      }
+    }
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonMediaImporter.java
@@ -21,45 +21,51 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
-import org.datatransferproject.types.common.models.videos.VideoAlbum;
+import org.datatransferproject.types.common.models.media.MediaAlbum;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.videos.VideoModel;
-import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
 import java.util.UUID;
 
 /**
- * Imports videos into Amazon Photos from other DTP-supported services.
+ * Imports the unified MEDIA vertical (albums + photos + videos in one {@link
+ * MediaContainerResource}) into Amazon Photos.
  *
- * <p>The per-job client, album creation, download+MD5, upload, and duplicate/quota handling live in
- * {@link AmazonImportHelper} and are shared with the photos and media importers; this class only
- * iterates the videos container and maps each video onto those shared operations.
+ * <p>Albums are created first so photos and videos can resolve their parent album from the {@link
+ * IdempotentImportExecutor} cache. All the actual work — per-job client provisioning, album
+ * creation, download+MD5, upload, and duplicate/quota handling — lives in {@link
+ * AmazonImportHelper} and is shared with the photos and videos importers; this class only maps the
+ * MEDIA container's three item types onto those shared operations.
  */
-public class AmazonVideosImporter
-    implements Importer<TokensAndUrlAuthData, VideosContainerResource> {
+public class AmazonMediaImporter
+    implements Importer<TokensAndUrlAuthData, MediaContainerResource> {
 
   private final AmazonImportHelper importHelper;
+  private final AmazonMediaTransmogrificationConfig transmogrificationConfig =
+      new AmazonMediaTransmogrificationConfig();
   private final IdempotentImportExecutor retryingIdempotentExecutor;
   private final boolean enableRetrying;
 
-  public AmazonVideosImporter(Monitor monitor, String clientId, String clientSecret,
-                              TemporaryPerJobDataStore dataStore,
-                              IdempotentImportExecutor retryingIdempotentExecutor,
-                              boolean enableRetrying) {
+  public AmazonMediaImporter(Monitor monitor, String clientId, String clientSecret,
+                             TemporaryPerJobDataStore dataStore,
+                             IdempotentImportExecutor retryingIdempotentExecutor,
+                             boolean enableRetrying) {
     this.importHelper = new AmazonImportHelper(dataStore, clientId, clientSecret, monitor);
     this.retryingIdempotentExecutor = retryingIdempotentExecutor;
     this.enableRetrying = enableRetrying;
   }
 
-  AmazonVideosImporter(Monitor monitor, TemporaryPerJobDataStore dataStore,
-                       AmazonPhotosInterface client) {
+  AmazonMediaImporter(Monitor monitor, TemporaryPerJobDataStore dataStore,
+                      AmazonPhotosInterface client) {
     this(monitor, dataStore, client, null, false);
   }
 
-  AmazonVideosImporter(Monitor monitor, TemporaryPerJobDataStore dataStore,
-                       AmazonPhotosInterface client,
-                       IdempotentImportExecutor retryingIdempotentExecutor,
-                       boolean enableRetrying) {
+  AmazonMediaImporter(Monitor monitor, TemporaryPerJobDataStore dataStore,
+                      AmazonPhotosInterface client,
+                      IdempotentImportExecutor retryingIdempotentExecutor,
+                      boolean enableRetrying) {
     this.importHelper = new AmazonImportHelper(dataStore, client, monitor);
     this.retryingIdempotentExecutor = retryingIdempotentExecutor;
     this.enableRetrying = enableRetrying;
@@ -68,8 +74,9 @@ public class AmazonVideosImporter
   @Override
   public ImportResult importItem(UUID jobId, IdempotentImportExecutor idempotentImportExecutor,
                                  TokensAndUrlAuthData authData,
-                                 VideosContainerResource data) throws Exception {
+                                 MediaContainerResource data) throws Exception {
     AmazonPhotosInterface client = importHelper.getOrCreateClient(jobId, authData);
+    data.transmogrify(transmogrificationConfig);
 
     // Prefer the platform's retrying executor when enabled so transient failures are retried
     // (per the host-configured RetryStrategyLibrary) before being recorded and skipped.
@@ -78,10 +85,17 @@ public class AmazonVideosImporter
             ? retryingIdempotentExecutor
             : idempotentImportExecutor;
 
-    for (VideoAlbum album : data.getAlbums()) {
+    // Albums first: photos and videos resolve their parent album from the executor cache.
+    for (MediaAlbum album : data.getAlbums()) {
       executor.executeAndSwallowIOExceptions(
           album.getId(), album.getName(),
           () -> importHelper.createAlbum(client, album.getId(), album.getName()));
+    }
+
+    for (PhotoModel photo : data.getPhotos()) {
+      executor.executeAndSwallowIOExceptions(
+          photo.getIdempotentId(), photo.getTitle(),
+          () -> importHelper.uploadItem(client, jobId, UploadItemRequest.forPhoto(photo), executor));
     }
 
     for (VideoModel video : data.getVideos()) {

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonMediaTransmogrificationConfig.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonMediaTransmogrificationConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import org.datatransferproject.types.common.models.TransmogrificationConfig;
+
+/**
+ * Amazon Photos size limits applied to a {@code MediaContainerResource} during the DTP
+ * transmogrification step: the maximum album-name, photo-title and video-title lengths that source
+ * data is trimmed to before import.
+ */
+public class AmazonMediaTransmogrificationConfig extends TransmogrificationConfig {
+
+  private static final int MAX_ALBUM_NAME_LENGTH = 200;
+  private static final int MAX_PHOTO_TITLE_LENGTH = 200;
+  private static final int MAX_VIDEO_TITLE_LENGTH = 200;
+
+  @Override
+  public int getAlbumNameMaxLength() {
+    return MAX_ALBUM_NAME_LENGTH;
+  }
+
+  @Override
+  public int getPhotoTitleMaxLength() {
+    return MAX_PHOTO_TITLE_LENGTH;
+  }
+
+  @Override
+  public int getVideoTitleMaxLength() {
+    return MAX_VIDEO_TITLE_LENGTH;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosImporter.java
@@ -21,33 +21,23 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
-import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
-import org.datatransferproject.transfer.JobMetadata;
-import org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode;
-import org.datatransferproject.types.common.models.FavoriteInfo;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
-import java.io.File;
-import java.io.IOException;
-import java.security.MessageDigest;
-import java.time.Instant;
-import java.util.Optional;
 import java.util.UUID;
 
 /**
  * Imports photos into Amazon Photos from other DTP-supported services.
  *
- * <p>For each photo: downloads to a temp file (computing MD5 in a single pass via
- * DigestInputStream), then uploads via the Upload Service. Duplicate detection and
- * fallback album placement are handled server-side.
+ * <p>The per-job client, album creation, download+MD5, upload, and duplicate/quota handling live in
+ * {@link AmazonImportHelper} and are shared with the videos and media importers; this class only
+ * iterates the photos container and supplies the photo-specific title and favorite flag.
  */
 public class AmazonPhotosImporter
     implements Importer<TokensAndUrlAuthData, PhotosContainerResource> {
 
-  private final Monitor monitor;
   private final AmazonImportHelper importHelper;
   private final AmazonPhotosTransmogrificationConfig transmogrificationConfig =
       new AmazonPhotosTransmogrificationConfig();
@@ -58,7 +48,6 @@ public class AmazonPhotosImporter
                               TemporaryPerJobDataStore dataStore,
                               IdempotentImportExecutor retryingIdempotentExecutor,
                               boolean enableRetrying) {
-    this.monitor = monitor;
     this.importHelper = new AmazonImportHelper(dataStore, clientId, clientSecret, monitor);
     this.retryingIdempotentExecutor = retryingIdempotentExecutor;
     this.enableRetrying = enableRetrying;
@@ -73,8 +62,7 @@ public class AmazonPhotosImporter
                        AmazonPhotosInterface client,
                        IdempotentImportExecutor retryingIdempotentExecutor,
                        boolean enableRetrying) {
-    this.monitor = monitor;
-    this.importHelper = new AmazonImportHelper(dataStore, client);
+    this.importHelper = new AmazonImportHelper(dataStore, client, monitor);
     this.retryingIdempotentExecutor = retryingIdempotentExecutor;
     this.enableRetrying = enableRetrying;
   }
@@ -95,61 +83,16 @@ public class AmazonPhotosImporter
 
     for (PhotoAlbum album : data.getAlbums()) {
       executor.executeAndSwallowIOExceptions(
-          album.getId(), album.getName(), () -> createAlbum(client, album));
+          album.getId(), album.getName(),
+          () -> importHelper.createAlbum(client, album.getId(), album.getName()));
     }
 
     for (PhotoModel photo : data.getPhotos()) {
       executor.executeAndSwallowIOExceptions(
           photo.getIdempotentId(), photo.getTitle(),
-          () -> uploadPhoto(client, jobId, photo, executor));
+          () -> importHelper.uploadItem(client, jobId, UploadItemRequest.forPhoto(photo), executor));
     }
 
     return ImportResult.OK;
-  }
-
-  private String createAlbum(AmazonPhotosInterface client, PhotoAlbum album) throws IOException {
-    String albumName = album.getName() + AmazonImportHelper.IMPORTED_SUFFIX + JobMetadata.getExportService();
-    AmazonPhotosNode node = client.createAlbum(albumName);
-    monitor.info(() -> "Created album " + album.getId() + " -> " + node.getId());
-    return node.getId();
-  }
-
-  private String uploadPhoto(AmazonPhotosInterface client, UUID jobId, PhotoModel photo,
-                             IdempotentImportExecutor executor) throws Exception {
-    String targetAlbumId = importHelper.resolveTargetAlbumId(photo.getAlbumId(), executor);
-    MessageDigest md5 = importHelper.newMd5Digest();
-    File tempFile = importHelper.downloadToTempFile(jobId, photo, photo.getDataId(), md5);
-
-    try {
-      String md5Hex = importHelper.toHexString(md5.digest());
-      long fileSize = tempFile.length();
-      String fallbackContentDate = Optional.ofNullable(photo.getUploadedTime())
-          .map(d -> d.toInstant().toString())
-          .orElse(Instant.now().toString());
-      boolean isFavorite = Optional.ofNullable(photo.getFavoriteInfo())
-          .map(FavoriteInfo::getFavorited)
-          .orElse(false);
-
-      AmazonPhotosNode uploadedNode = client.uploadContent(
-          photo.getTitle(), tempFile, md5Hex,
-          fileSize, fallbackContentDate, isFavorite, targetAlbumId);
-
-      return uploadedNode.getId();
-
-    } catch (AmazonPhotosApiException e) {
-      if (importHelper.isDuplicate(e)) {
-        monitor.info(() -> "Duplicate photo skipped: " + photo.getDataId());
-        return photo.getDataId();
-      }
-      if (importHelper.isStorageQuotaExceeded(e)) {
-        throw new DestinationMemoryFullException("Amazon Photos storage full", e);
-      }
-      throw e;
-    } finally {
-      tempFile.delete();
-      if (photo.isInTempStore()) {
-        importHelper.cleanupTempData(jobId, photo.getFetchableUrl());
-      }
-    }
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/UploadItemRequest.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/UploadItemRequest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import org.datatransferproject.types.common.DownloadableItem;
+import org.datatransferproject.types.common.models.FavoriteInfo;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.videos.VideoModel;
+
+import java.util.Date;
+import java.util.Optional;
+
+/**
+ * Immutable parameter object describing a single item to upload via {@link
+ * AmazonImportHelper#uploadItem}: the source item plus its display name, data id, album id,
+ * uploaded time and favorite flag.
+ *
+ * <p>Instances are created only through {@link #forPhoto} and {@link #forVideo}, which keeps the
+ * photo/video field mapping in one place and spares call sites from ordering several
+ * similarly-typed arguments by hand.
+ */
+final class UploadItemRequest {
+
+  final DownloadableItem item;
+  final String displayName;
+  final String dataId;
+  final String albumId;
+  final Date uploadedTime;
+  final boolean isFavorite;
+
+  private UploadItemRequest(DownloadableItem item, String displayName, String dataId,
+                            String albumId, Date uploadedTime, boolean isFavorite) {
+    this.item = item;
+    this.displayName = displayName;
+    this.dataId = dataId;
+    this.albumId = albumId;
+    this.uploadedTime = uploadedTime;
+    this.isFavorite = isFavorite;
+  }
+
+  static UploadItemRequest forPhoto(PhotoModel photo) {
+    return new UploadItemRequest(photo, photo.getTitle(), photo.getDataId(), photo.getAlbumId(),
+        photo.getUploadedTime(), favorited(photo.getFavoriteInfo()));
+  }
+
+  static UploadItemRequest forVideo(VideoModel video) {
+    return new UploadItemRequest(video, video.getName(), video.getDataId(), video.getAlbumId(),
+        video.getUploadedTime(), favorited(video.getFavoriteInfo()));
+  }
+
+  private static boolean favorited(FavoriteInfo favoriteInfo) {
+    return Optional.ofNullable(favoriteInfo).map(FavoriteInfo::getFavorited).orElse(false);
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonImportHelperTest.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonImportHelperTest.java
@@ -19,6 +19,8 @@ package org.datatransferproject.transfer.amazon.photos;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -27,9 +29,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -92,7 +97,7 @@ class AmazonImportHelperTest {
   void getOrCreateClient_returnsInjectedClientWithoutBuilding() throws Exception {
     AmazonPhotosInterface injected = mock(AmazonPhotosInterface.class);
     AmazonImportHelper h =
-        new AmazonImportHelper(mock(TemporaryPerJobDataStore.class), injected);
+        new AmazonImportHelper(mock(TemporaryPerJobDataStore.class), injected, mock(Monitor.class));
 
     assertEquals(injected, h.getOrCreateClient(UUID.randomUUID(), AUTH_DATA));
     // Injected clients are supplied ready-to-use; the helper must not resolve endpoints itself.
@@ -125,5 +130,36 @@ class AmazonImportHelperTest {
         mock(TemporaryPerJobDataStore.class), "client-id", "client-secret", mock(Monitor.class));
     // Constructing the client does no network I/O (endpoint resolution is a separate call).
     assertNotNull(h.createClient(AUTH_DATA));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Album resolution: items resolve their parent album from the executor cache, which is
+  // populated because albums are always created before any item that references them.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void resolveTargetAlbumId_nullAlbumId_returnsNull() throws Exception {
+    IdempotentImportExecutor executor = mock(IdempotentImportExecutor.class);
+    // An albumless item has no parent to resolve.
+    assertNull(helper.resolveTargetAlbumId(null, executor));
+    verifyNoInteractions(executor);
+  }
+
+  @Test
+  void resolveTargetAlbumId_cachedAlbum_returnsAmazonNodeId() throws Exception {
+    IdempotentImportExecutor executor = mock(IdempotentImportExecutor.class);
+    // Album was created earlier this job, so its source id maps to the Amazon node id.
+    when(executor.getCachedValue("google-album")).thenReturn("amazon-node-1");
+    assertEquals("amazon-node-1", helper.resolveTargetAlbumId("google-album", executor));
+  }
+
+  @Test
+  void resolveTargetAlbumId_uncachedAlbum_propagates() throws Exception {
+    IdempotentImportExecutor executor = mock(IdempotentImportExecutor.class);
+    // No silent root fallback: an album id that wasn't created (not cached) fails the item so its
+    // album organization isn't silently lost, rather than reassigning it to some default album.
+    when(executor.getCachedValue("missing")).thenThrow(new IllegalArgumentException("not found"));
+    assertThrows(IllegalArgumentException.class,
+        () -> helper.resolveTargetAlbumId("missing", executor));
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonMediaImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonMediaImporterTest.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
+import org.datatransferproject.transfer.JobMetadata;
+import org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode;
+import org.datatransferproject.types.common.models.FavoriteInfo;
+import org.datatransferproject.types.common.models.media.MediaAlbum;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.videos.VideoModel;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+@ExtendWith(MockitoExtension.class)
+public class AmazonMediaImporterTest {
+
+  @Mock private Monitor monitor;
+  @Mock private TemporaryPerJobDataStore dataStore;
+  @Mock private IdempotentImportExecutor executor;
+  @Mock private IdempotentImportExecutor retryingExecutor;
+  @Mock private AmazonPhotosInterface client;
+
+  private TokensAndUrlAuthData authData;
+  private AmazonMediaImporter importer;
+  private UUID jobId;
+
+  @BeforeEach
+  void setUp() {
+    authData = new TokensAndUrlAuthData("access", "refresh", "http://token-url");
+    importer = new AmazonMediaImporter(monitor, dataStore, client);
+    jobId = UUID.randomUUID();
+  }
+
+  private static MediaContainerResource media(
+      List<MediaAlbum> albums, List<PhotoModel> photos, List<VideoModel> videos) {
+    return new MediaContainerResource(albums, photos, videos);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Retrying-executor selection (platform retry opt-in).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void importItem_usesRetryingExecutorWhenEnabled() throws Exception {
+    AmazonMediaImporter retryingImporter =
+        new AmazonMediaImporter(monitor, dataStore, client, retryingExecutor, true);
+    MediaAlbum album = new MediaAlbum("a1", "Album", null);
+    MediaContainerResource resource =
+        media(Collections.singletonList(album), Collections.emptyList(), Collections.emptyList());
+
+    retryingImporter.importItem(jobId, executor, authData, resource);
+
+    verify(retryingExecutor).executeAndSwallowIOExceptions(eq("a1"), eq("Album"), any());
+    verifyNoInteractions(executor);
+  }
+
+  @Test
+  void importItem_usesDefaultExecutorWhenRetryingDisabled() throws Exception {
+    AmazonMediaImporter retryingImporter =
+        new AmazonMediaImporter(monitor, dataStore, client, retryingExecutor, false);
+    MediaAlbum album = new MediaAlbum("a1", "Album", null);
+    MediaContainerResource resource =
+        media(Collections.singletonList(album), Collections.emptyList(), Collections.emptyList());
+
+    retryingImporter.importItem(jobId, executor, authData, resource);
+
+    verify(executor).executeAndSwallowIOExceptions(eq("a1"), eq("Album"), any());
+    verifyNoInteractions(retryingExecutor);
+  }
+
+  @Test
+  void importItem_usesDefaultExecutorWhenNoRetryingExecutorProvided() throws Exception {
+    AmazonMediaImporter retryingImporter =
+        new AmazonMediaImporter(monitor, dataStore, client, null, true);
+    MediaAlbum album = new MediaAlbum("a1", "Album", null);
+    MediaContainerResource resource =
+        media(Collections.singletonList(album), Collections.emptyList(), Collections.emptyList());
+
+    retryingImporter.importItem(jobId, executor, authData, resource);
+
+    verify(executor).executeAndSwallowIOExceptions(eq("a1"), eq("Album"), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unified MEDIA container registers albums, photos AND videos with the executor.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void importItem_registersAlbumsPhotosAndVideos() throws Exception {
+    MediaAlbum album = new MediaAlbum("a1", "Album", null);
+    PhotoModel photo = new PhotoModel("pic.jpg", "tempkey",
+        null, "image/jpeg", "p1", null, true, (Date) null);
+    VideoModel video = new VideoModel("clip.mp4", "tempkey",
+        "A video", "video/mp4", "vid-1", null, true, null);
+    MediaContainerResource resource = media(
+        Collections.singletonList(album),
+        Collections.singletonList(photo),
+        Collections.singletonList(video));
+
+    ImportResult result = importer.importItem(jobId, executor, authData, resource);
+
+    assertEquals(ImportResult.OK, result);
+    verify(executor).executeAndSwallowIOExceptions(eq("a1"), eq("Album"), any());
+    verify(executor).executeAndSwallowIOExceptions(
+        eq(photo.getIdempotentId()), eq("pic.jpg"), any());
+    verify(executor).executeAndSwallowIOExceptions(
+        eq(video.getIdempotentId()), eq("clip.mp4"), any());
+    // ...and nothing else.
+    verify(executor, times(3)).executeAndSwallowIOExceptions(any(), any(), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Storage-quota classification -> terminal DestinationMemoryFullException.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void importItem_noActiveSubscription_throwsDestinationMemoryFull() throws Exception {
+    PhotoModel photo = new PhotoModel("pic.jpg", "tempkey",
+        null, "image/jpeg", "p1", null, true, (Date) null);
+    MediaContainerResource resource = media(
+        Collections.emptyList(), Collections.singletonList(photo), Collections.emptyList());
+
+    stubDownload();
+    executorRunsCallable();
+    when(client.uploadContent(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
+        .thenThrow(new AmazonPhotosApiException(403, "NoActiveSubscriptionFound", "no subscription"));
+
+    assertThrows(DestinationMemoryFullException.class,
+        () -> importer.importItem(jobId, executor, authData, resource));
+  }
+
+  // ---------------------------------------------------------------------------
+  // createAlbum body (requires the JobMetadata worker singleton, mocked statically).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void importItem_createAlbum_invokesClientWithSuffixedNameAndReturnsId() throws Exception {
+    MediaAlbum album = new MediaAlbum("a1", "Vacation", "desc");
+    MediaContainerResource resource =
+        media(Collections.singletonList(album), Collections.emptyList(), Collections.emptyList());
+
+    AmazonPhotosNode node = new AmazonPhotosNode();
+    node.setId("amazon-album-1");
+    when(client.createAlbum(any())).thenReturn(node);
+    executorRunsCallable();
+
+    try (MockedStatic<JobMetadata> jm = mockStatic(JobMetadata.class)) {
+      jm.when(JobMetadata::getExportService).thenReturn("Google");
+      importer.importItem(jobId, executor, authData, resource);
+    }
+
+    org.mockito.ArgumentCaptor<String> name = org.mockito.ArgumentCaptor.forClass(String.class);
+    verify(client).createAlbum(name.capture());
+    assertEquals("Vacation" + AmazonImportHelper.IMPORTED_SUFFIX + "Google", name.getValue());
+  }
+
+  // ---------------------------------------------------------------------------
+  // uploadPhoto happy path (covers uploadedTime + favorite mapping, upload, temp cleanup).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void importItem_uploadPhoto_happyPath_withUploadedTimeAndFavorite() throws Exception {
+    Date uploaded = new Date(1_700_000_000_000L);
+    PhotoModel photo = new PhotoModel("pic.jpg", "tempkey", null, "image/jpeg",
+        "p1", null, true, null, uploaded, new FavoriteInfo(true, uploaded));
+    MediaContainerResource resource = media(
+        Collections.emptyList(), Collections.singletonList(photo), Collections.emptyList());
+
+    stubDownload();
+    executorRunsCallable();
+    AmazonPhotosNode node = new AmazonPhotosNode();
+    node.setId("uploaded-1");
+    when(client.uploadContent(eq("pic.jpg"), any(), any(), any(Long.class),
+        eq(uploaded.toInstant().toString()), eq(true), eq(null))).thenReturn(node);
+
+    importer.importItem(jobId, executor, authData, resource);
+
+    verify(client).uploadContent(eq("pic.jpg"), any(), any(), any(Long.class),
+        eq(uploaded.toInstant().toString()), eq(true), eq(null));
+    // inTempStore == true -> temp data is cleaned up after upload.
+    verify(dataStore).removeData(jobId, "tempkey");
+  }
+
+  // ---------------------------------------------------------------------------
+  // uploadVideo happy path (covers uploadedTime mapping, non-favorite, upload, temp cleanup).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void importItem_uploadVideo_happyPath_withUploadedTime() throws Exception {
+    Date uploaded = new Date(1_700_000_000_000L);
+    VideoModel video = new VideoModel("clip.mp4", "tempkey", "A video", "video/mp4",
+        "vid-1", null, true, uploaded);
+    MediaContainerResource resource = media(
+        Collections.emptyList(), Collections.emptyList(), Collections.singletonList(video));
+
+    stubDownload();
+    executorRunsCallable();
+    AmazonPhotosNode node = new AmazonPhotosNode();
+    node.setId("uploaded-1");
+    when(client.uploadContent(eq("clip.mp4"), any(), any(), any(Long.class),
+        eq(uploaded.toInstant().toString()), eq(false), eq(null))).thenReturn(node);
+
+    importer.importItem(jobId, executor, authData, resource);
+
+    verify(client).uploadContent(eq("clip.mp4"), any(), any(), any(Long.class),
+        eq(uploaded.toInstant().toString()), eq(false), eq(null));
+    verify(dataStore).removeData(jobId, "tempkey");
+  }
+
+  @Test
+  void importItem_uploadVideo_favorited_passesFavoriteTrue() throws Exception {
+    Date uploaded = new Date(1_700_000_000_000L);
+    VideoModel video = new VideoModel("clip.mp4", "tempkey", "A video", "video/mp4",
+        "vid-1", null, true, uploaded, new FavoriteInfo(true, uploaded));
+    MediaContainerResource resource = media(
+        Collections.emptyList(), Collections.emptyList(), Collections.singletonList(video));
+
+    stubDownload();
+    executorRunsCallable();
+    AmazonPhotosNode node = new AmazonPhotosNode();
+    node.setId("uploaded-1");
+    when(client.uploadContent(eq("clip.mp4"), any(), any(), any(Long.class), any(),
+        eq(true), any())).thenReturn(node);
+
+    importer.importItem(jobId, executor, authData, resource);
+
+    // Guards the fix: a favorited video is uploaded with isFavorite=true, not a hardcoded false.
+    verify(client).uploadContent(eq("clip.mp4"), any(), any(), any(Long.class), any(),
+        eq(true), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Duplicate handling: swallowed as success for both photos and videos.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void importItem_uploadPhoto_duplicate_isSkippedWithoutError() throws Exception {
+    PhotoModel photo = new PhotoModel("pic.jpg", "tempkey",
+        null, "image/jpeg", "p1", null, true, (Date) null);
+    MediaContainerResource resource = media(
+        Collections.emptyList(), Collections.singletonList(photo), Collections.emptyList());
+
+    stubDownload();
+    executorRunsCallable();
+    when(client.uploadContent(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
+        .thenThrow(new AmazonPhotosApiException(409, "DuplicatesConflictError", "dup"));
+
+    ImportResult result = importer.importItem(jobId, executor, authData, resource);
+
+    assertEquals(ImportResult.OK, result);
+    verify(client).uploadContent(eq("pic.jpg"), any(), any(), any(Long.class), any(), any(Boolean.class), any());
+  }
+
+  @Test
+  void importItem_uploadVideo_duplicate_isSkippedWithoutError() throws Exception {
+    VideoModel video = new VideoModel("clip.mp4", "tempkey",
+        "A video", "video/mp4", "vid-1", null, true, null);
+    MediaContainerResource resource = media(
+        Collections.emptyList(), Collections.emptyList(), Collections.singletonList(video));
+
+    stubDownload();
+    executorRunsCallable();
+    when(client.uploadContent(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
+        .thenThrow(new AmazonPhotosApiException(409, "DuplicatesConflictError", "dup"));
+
+    ImportResult result = importer.importItem(jobId, executor, authData, resource);
+
+    assertEquals(ImportResult.OK, result);
+    verify(client).uploadContent(eq("clip.mp4"), any(), any(), any(Long.class), any(), any(Boolean.class), any());
+  }
+
+  @Test
+  void importItem_uploadPhoto_nonDuplicateNonQuotaError_propagates() throws Exception {
+    PhotoModel photo = new PhotoModel("pic.jpg", "tempkey",
+        null, "image/jpeg", "p1", null, true, (Date) null);
+    MediaContainerResource resource = media(
+        Collections.emptyList(), Collections.singletonList(photo), Collections.emptyList());
+
+    stubDownload();
+    executorRunsCallable();
+    when(client.uploadContent(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
+        .thenThrow(new AmazonPhotosApiException(403, "ForbiddenAccess", "denied"));
+
+    assertThrows(AmazonPhotosApiException.class,
+        () -> importer.importItem(jobId, executor, authData, resource));
+  }
+
+  @Test
+  void productionConstructor_buildsWithoutNetwork() {
+    // Exercises the production wiring; the client is built lazily per job, not at construction.
+    assertNotNull(new AmazonMediaImporter(
+        monitor, "client-id", "client-secret", dataStore, null, false));
+  }
+
+  @Test
+  void importItem_photoWithAlbum_resolvesToCreatedAlbumNodeId() throws Exception {
+    // Albums are created before items, so a photo referencing an album resolves (via the executor
+    // cache) to that album's Amazon node id, which is passed as the uploadContent albumId.
+    PhotoModel photo = new PhotoModel("pic.jpg", "tempkey",
+        null, "image/jpeg", "p1", "a1", true, (Date) null);
+    MediaContainerResource resource = media(
+        Collections.emptyList(), Collections.singletonList(photo), Collections.emptyList());
+
+    stubDownload();
+    executorRunsCallable();
+    when(executor.getCachedValue("a1")).thenReturn("amazon-album-1");
+    AmazonPhotosNode node = new AmazonPhotosNode();
+    node.setId("uploaded-1");
+    when(client.uploadContent(eq("pic.jpg"), any(), any(), any(Long.class), any(),
+        any(Boolean.class), eq("amazon-album-1"))).thenReturn(node);
+
+    importer.importItem(jobId, executor, authData, resource);
+
+    verify(client).uploadContent(eq("pic.jpg"), any(), any(), any(Long.class), any(),
+        any(Boolean.class), eq("amazon-album-1"));
+  }
+
+  private void stubDownload() throws Exception {
+    InputStream stream = new java.io.ByteArrayInputStream(new byte[]{1, 2, 3});
+    when(dataStore.getStream(eq(jobId), eq("tempkey")))
+        .thenReturn(new TemporaryPerJobDataStore.InputStreamWrapper(stream));
+    File tempFile = File.createTempFile("test", ".tmp");
+    tempFile.deleteOnExit();
+    when(dataStore.getTempFileFromInputStream(any(), any(), any())).thenReturn(tempFile);
+  }
+
+  private void executorRunsCallable() throws Exception {
+    when(executor.executeAndSwallowIOExceptions(any(), any(), any()))
+        .thenAnswer(invocation ->
+            ((java.util.concurrent.Callable<?>) invocation.getArgument(2)).call());
+  }
+}


### PR DESCRIPTION

  ### Summary
  Adds support for the `MEDIA` data vertical to the Amazon Photos extension. reusing the shared import path introduced with the Photos/Videos importers (#1512, #1513).
  
  ### Changes
  - **`AmazonMediaImporter`** — imports `MediaContainerResource` (albums + photos + videos) into Amazon Photos, delegating album creation, download+MD5, upload, and duplicate/quota handling to
  the shared `AmazonImportHelper`.
  - **`UploadItemRequest`** — new immutable parameter object with `forPhoto`/`forVideo` factories; keeps the per-vertical field mapping in one place. `AmazonPhotosImporter` and
  `AmazonVideosImporter` are refactored to use it, removing duplicated upload wiring.
  - **`AmazonMediaTransmogrificationConfig`** — transmogrification config for the MEDIA vertical.
  - **`AmazonTransferExtension`** — registers the importer for `DataVertical.MEDIA`.
  - **`AmazonOAuthConfig`** — adds import/export scopes for the MEDIA vertical.
  - **`AmazonImportHelper`** — shared upload/album operations extended to serve the media importer.
  
  ### Testing
  - Completed transfer using the vertical successfully for both videos and photos. 
  - New `AmazonMediaImporterTest` covers albums+photos+videos registration, favorited items, duplicate skip, insufficient-storage → `DestinationMemoryFullException`, retry-executor selection,
  and happy-path uploads with uploaded time.
  - New `AmazonOAuthConfigTest` cases for media import/export scopes.